### PR TITLE
Plot and Plot extensions setup

### DIFF
--- a/charts/Area.args.js
+++ b/charts/Area.args.js
@@ -1,0 +1,51 @@
+import React from "react";
+import {argTypes as plotArgTypes} from "./Plot.args";
+
+import {AreaPlot as D3plusArea} from "d3plus-react";
+export const Area = ({config}) => <D3plusArea config={config} />;
+
+export const argTypes = {
+
+    /**
+     * Filters out unused argTypes from the Plot args and
+     * overrides any defaults that have been changed in AreaPlot
+     */
+    ...Object.keys(plotArgTypes)
+      .reduce((obj, k) => (obj[k] = plotArgTypes[k], obj), {}),
+
+    /**
+     * Area-specific methods
+     */
+
+    baseline: {
+      defaultValue: 0,
+      table: {
+        defaultValue: {
+          summary: 0
+        }
+      }
+    },
+    discrete: {
+      defaultValue: "x",
+      table: {
+        defaultValue: {
+          summary: "x"
+        }
+      }
+    },
+    shape: {
+      table: {
+        defaultValue: {
+          summary: "Area"
+        }
+      }
+    },
+    x: {
+      defaultValue: "x",
+      table: {
+        defaultValue: {
+          summary: "x"
+        }
+      }
+    }
+}

--- a/charts/Area.stories.js
+++ b/charts/Area.stories.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import {argTypes, Area} from './Area.args';
+import configify from "../helpers/configify";
+
+export default {
+  title: "Charts/Area",
+  component: Area,
+  argTypes
+};
+
+const Template = (args) => <Area config={configify(args, argTypes)} />;
+
+export const GettingStarted = Template.bind({});
+GettingStarted.args = {
+  data: [
+    {id: "alpha", x: 1, y: 7},
+    {id: "alpha", x: 2, y: 2},
+    {id: "alpha", x: 3, y: 13},
+    {id: "alpha", x: 4, y: 4},
+    {id: "alpha", x: 5, y: 22},
+    {id: "alpha", x: 6, y: 13}
+  ],
+  groupBy: "id"
+};
+
+export const ChangingAreaOpacity = Template.bind({});
+ChangingAreaOpacity.args = {
+  data: [
+    {id: "alpha", x: 1, y: 7},
+    {id: "alpha", x: 2, y: 2},
+    {id: "alpha", x: 3, y: 13},
+    {id: "alpha", x: 4, y: 4},
+    {id: "alpha", x: 5, y: 22},
+    {id: "alpha", x: 6, y: 13},
+    {id: "beta", x: 1, y: 10},
+    {id: "beta", x: 2, y: 6},
+    {id: "beta", x: 3, y: 15},
+    {id: "beta", x: 4, y: 12},
+    {id: "beta", x: 5, y: 11},
+    {id: "beta", x: 6, y: 7}
+  ],
+  groupBy: "id",
+  shapeConfig: {
+    Area: {
+      fillOpacity: 0.5
+    }
+  }
+};

--- a/charts/BarChart.args.js
+++ b/charts/BarChart.args.js
@@ -1,0 +1,65 @@
+import React from "react";
+import {argTypes as plotArgTypes} from "./Plot.args";
+
+import {BarChart as D3plusBarChart} from "d3plus-react";
+export const BarChart = ({config}) => <D3plusBarChart config={config} />;
+
+export const argTypes = {
+
+    /**
+     * Filters out unused argTypes from the Plot args and
+     * overrides any defaults that have been changed in BarChart
+     */
+    ...Object.keys(plotArgTypes)
+      .reduce((obj, k) => (obj[k] = plotArgTypes[k], obj), {}),
+
+    /**
+     * BarChart-specific methods
+     */
+
+    baseline: {
+      defaultValue: 0,
+      table: {
+        defaultValue: {
+          summary: 0
+        }
+      }
+    },
+    discrete: {
+      defaultValue: "x",
+      table: {
+        defaultValue: {
+          summary: "x"
+        }
+      }
+    },
+    legend: {
+      table: {
+        category: "Legends",
+        defaultValue: {
+          summary: "function",
+          detail: `function(config, arr) {
+  const legendIds = arr.map(this._groupBy[this._legendDepth].bind(this)).sort().join();
+  const barIds = this._filteredData.map(this._groupBy[this._legendDepth].bind(this)).sort().join();
+  if (legendIds === barIds) return false;
+  return defaultLegend.bind(this)(config, arr);
+}`
+        }
+      }
+    },
+    shape: {
+      table: {
+        defaultValue: {
+          summary: "Bar"
+        }
+      }
+    },
+    x: {
+      defaultValue: "x",
+      table: {
+        defaultValue: {
+          summary: "x"
+        }
+      }
+    }
+}

--- a/charts/BarChart.args.js
+++ b/charts/BarChart.args.js
@@ -1,22 +1,23 @@
 import React from "react";
-import {argTypes as plotArgTypes} from "./Plot.args";
+import { argTypes as plotArgTypes } from "./Plot.args";
+import { assign } from "d3plus-common";
 
-import {BarChart as D3plusBarChart} from "d3plus-react";
-export const BarChart = ({config}) => <D3plusBarChart config={config} />;
+import { BarChart as D3plusBarChart } from "d3plus-react";
+export const BarChart = ({ config }) => <D3plusBarChart config={config} />;
 
-export const argTypes = {
+export const argTypes = assign(
 
-    /**
-     * Filters out unused argTypes from the Plot args and
-     * overrides any defaults that have been changed in BarChart
-     */
-    ...Object.keys(plotArgTypes)
-      .reduce((obj, k) => (obj[k] = plotArgTypes[k], obj), {}),
+  /**
+   * Filters out unused argTypes from the Plot args and
+   * overrides any defaults that have been changed in BarChart
+   */
+  Object.keys(plotArgTypes)
+    .reduce((obj, k) => (obj[k] = plotArgTypes[k], obj), {}),
 
-    /**
-     * BarChart-specific methods
-     */
-
+  /**
+   * BarChart-specific methods
+   */
+  {
     baseline: {
       defaultValue: 0,
       table: {
@@ -62,4 +63,5 @@ export const argTypes = {
         }
       }
     }
-}
+  }
+);

--- a/charts/BarChart.args.js
+++ b/charts/BarChart.args.js
@@ -36,7 +36,6 @@ export const argTypes = assign(
     },
     legend: {
       table: {
-        category: "Legends",
         defaultValue: {
           summary: "function",
           detail: `function(config, arr) {

--- a/charts/BarChart.stories.js
+++ b/charts/BarChart.stories.js
@@ -25,8 +25,65 @@ GettingStarted.args = {
   groupBy: "id"
 };
 
-export const HorizontalBarchart = Template.bind({});
-HorizontalBarchart.args = {
+export const BarChartSorting = Template.bind({});
+BarChartSorting.args = {
+  data: [
+    {"Travel Time": "< 5 Minutes",     "ID Travel Time": "0", "Population Percentage":  2},
+    {"Travel Time": "15 - 24 Minutes", "ID Travel Time": "2", "Population Percentage": 30},
+    {"Travel Time": "35 - 44 Minutes", "ID Travel Time": "4", "Population Percentage":  7},
+    {"Travel Time": "45 - 89 Minutes", "ID Travel Time": "5", "Population Percentage": 11},
+    {"Travel Time": "5 - 14 Minutes",  "ID Travel Time": "1", "Population Percentage": 20},
+    {"Travel Time": "90+ Minutes",     "ID Travel Time": "6", "Population Percentage":  5},
+    {"Travel Time": "25 - 34 Minutes", "ID Travel Time": "3", "Population Percentage": 25}
+  ],
+  groupBy: "Travel Time",
+  x: "Travel Time",
+  y: "Population Percentage",
+  xSort: function(a, b) {
+    return a["ID Travel Time"] - b["ID Travel Time"];
+  }
+};
+
+export const CustomBarChartPadding = Template.bind({});
+CustomBarChartPadding.args = {
+  data: "https://datamexico.org/api/data?Indicator=62,63,64&Sector=31-33&cube=indicators_economic_census&drilldowns=Indicator,Category&measures=Value,Percentage&parents=false&locale=en",
+  groupBy: "Indicator",
+  barPadding: 0,
+  groupPadding: 40,
+  label: function(d) {
+    return `${formatAbbreviate(d["Percentage"])}%`;
+  },
+  legend: false,
+  x: "Category",
+  y: "Percentage",
+  yConfig: {
+    tickFormat: function(d) {
+      return `${d}%`;
+    },
+    title: false
+  }
+}
+
+export const GroupedBarChart = Template.bind({});
+GroupedBarChart.args = {
+  data: "https://datamexico.org/api/data?Indicator=62,63,64&Sector=31-33&cube=indicators_economic_census&drilldowns=Indicator,Category&measures=Value,Percentage&parents=false&locale=en",
+  groupBy: "Indicator",
+  label: function(d) {
+    return `${formatAbbreviate(d["Percentage"])}%`;
+  },
+  legend: false,
+  x: "Category",
+  y: "Percentage",
+  yConfig: {
+    tickFormat: function(d) {
+      return `${d}%`;
+    },
+    title: false
+  }
+}
+
+export const HorizontalBarChart = Template.bind({});
+HorizontalBarChart.args = {
   data: [
     {id: "alpha", x: 4, y:  7},
     {id: "alpha", x: 5, y: 25},
@@ -43,6 +100,23 @@ HorizontalBarchart.args = {
     title: ""
   },
   y: "x"
+};
+
+export const PercentStackedBarChart = Template.bind({});
+PercentStackedBarChart.args = {
+  data: "https://datamexico.org/api/data?Indicator=107&Nation=mex&cube=indicators_economic_census&drilldowns=Category,Indicator,Sector&measures=Percentage&parents=false&locale=en",
+  groupBy: ["Category"],
+  discrete: "y",
+  height: 600,
+  legendPosition: "bottom",
+  stacked: true,
+  x: "Percentage",
+  xConfig: {
+    tickFormat: function(d) {
+      return `${d}%`;
+    }
+  },
+  y: "Sector"
 };
 
 export const PopulationPyramid = Template.bind({});
@@ -307,4 +381,18 @@ PopulationPyramid.args = {
     }
   },
   y: "Age range"
+};
+
+export const StackedBarChart = Template.bind({});
+StackedBarChart.args = {
+  data: [
+    {id: "alpha", x: 4, y:  7},
+    {id: "alpha", x: 5, y: 25},
+    {id: "alpha", x: 6, y: 13},
+    {id: "beta",  x: 4, y: 17},
+    {id: "beta",  x: 5, y:  8},
+    {id: "beta",  x: 6, y: 13}
+  ],
+  groupBy: "id",
+  stacked: true
 };

--- a/charts/BarChart.stories.js
+++ b/charts/BarChart.stories.js
@@ -1,0 +1,310 @@
+import React from 'react';
+import {argTypes, BarChart} from './BarChart.args';
+import configify from "../helpers/configify";
+
+import {formatAbbreviate} from 'd3plus-format';
+
+export default {
+  title: "Charts/BarChart",
+  component: BarChart,
+  argTypes
+};
+
+const Template = (args) => <BarChart config={configify(args, argTypes)} />;
+
+export const GettingStarted = Template.bind({});
+GettingStarted.args = {
+  data: [
+    {id: "alpha", x: 4, y:  7},
+    {id: "alpha", x: 5, y: 25},
+    {id: "alpha", x: 6, y: 13},
+    {id: "beta",  x: 4, y: 17},
+    {id: "beta",  x: 5, y:  8},
+    {id: "beta",  x: 6, y: 13}
+  ],
+  groupBy: "id"
+};
+
+export const HorizontalBarchart = Template.bind({});
+HorizontalBarchart.args = {
+  data: [
+    {id: "alpha", x: 4, y:  7},
+    {id: "alpha", x: 5, y: 25},
+    {id: "alpha", x: 6, y: 13},
+    {id: "beta",  x: 4, y: 17},
+    {id: "beta",  x: 5, y:  8},
+    {id: "beta",  x: 6, y: 13}
+
+  ],
+  groupBy: "id",
+  discrete: "y",
+  x: "y",
+  xConfig: {
+    title: ""
+  },
+  y: "x"
+};
+
+export const PopulationPyramid = Template.bind({});
+PopulationPyramid.args = {
+  data: [
+    {
+      "Age range ID": 1,
+      "Age range": "0 to 4",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 1445122
+    },
+    {
+      "Age range ID": 1,
+      "Age range": "0 to 4",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -1385933
+    },
+    {
+      "Age range ID": 2,
+      "Age range": "5 to 9",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 1473968
+    },
+    {
+      "Age range ID": 2,
+      "Age range": "5 to 9",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -1417319
+    },
+    {
+      "Age range ID": 3,
+      "Age range": "10 to 15",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 1483727
+    },
+    {
+      "Age range ID": 3,
+      "Age range": "10 to 15",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -1430083
+    },
+    {
+      "Age range ID": 4,
+      "Age range": "15 to 19",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 1466289
+    },
+    {
+      "Age range ID": 4,
+      "Age range": "15 to 19",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -1420257
+    },
+    {
+      "Age range ID": 5,
+      "Age range": "20 to 24",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 1438000
+    },
+    {
+      "Age range ID": 5,
+      "Age range": "20 to 24",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -1401017
+    },
+    {
+      "Age range ID": 6,
+      "Age range": "25 to 29",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 1371191
+    },
+    {
+      "Age range ID": 6,
+      "Age range": "25 to 29",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -1344048
+    },
+    {
+      "Age range ID": 7,
+      "Age range": "30 to 34",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 1251238
+    },
+    {
+      "Age range ID": 7,
+      "Age range": "30 to 34",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -1233884
+    },
+    {
+      "Age range ID": 8,
+      "Age range": "35 to 39",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 1156915
+    },
+    {
+      "Age range ID": 8,
+      "Age range": "35 to 39",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -1145477
+    },
+    {
+      "Age range ID": 9,
+      "Age range": "40 to 44",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 1038422
+    },
+    {
+      "Age range ID": 9,
+      "Age range": "40 to 44",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -1034343
+    },
+    {
+      "Age range ID": 10,
+      "Age range": "45 to 49",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 899326
+    },
+    {
+      "Age range ID": 10,
+      "Age range": "45 to 49",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -903752
+    },
+    {
+      "Age range ID": 11,
+      "Age range": "50 to 54",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 774590
+    },
+    {
+      "Age range ID": 11,
+      "Age range": "50 to 54",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -788241
+    },
+    {
+      "Age range ID": 12,
+      "Age range": "55 to 59",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 634510
+    },
+    {
+      "Age range ID": 12,
+      "Age range": "55 to 59",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -658490
+    },
+    {
+      "Age range ID": 13,
+      "Age range": "60 to 64",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 501128
+    },
+    {
+      "Age range ID": 13,
+      "Age range": "60 to 64",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -532940
+    },
+    {
+      "Age range ID": 14,
+      "Age range": "65 to 69",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 379352
+    },
+    {
+      "Age range ID": 14,
+      "Age range": "65 to 69",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -415647
+    },
+    {
+      "Age range ID": 15,
+      "Age range": "70 to 74",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 271687
+    },
+    {
+      "Age range ID": 15,
+      "Age range": "70 to 74",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -311231
+    },
+    {
+      "Age range ID": 16,
+      "Age range": "75 to 79",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 186805
+    },
+    {
+      "Age range ID": 16,
+      "Age range": "75 to 79",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -229221
+    },
+    {
+      "Age range ID": 17,
+      "Age range": "80+",
+      "Sex ID": 1,
+      "Sex": "Male",
+      "Population": 166789
+    },
+    {
+      "Age range ID": 17,
+      "Age range": "80+",
+      "Sex ID": 2,
+      "Sex": "Female",
+      "Population": -235076
+    }
+  ],
+  groupBy: ["Sex"],
+  height: 400,
+  discrete: "y",
+  shapeConfig: {
+    label: function(d) {return ""}
+  },
+  stacked: true,
+  tooltipConfig: {
+    tbody: [
+      ["Age range:", function(d) {return d["Age range"]}],
+      ["Population:", function(d) {return formatAbbreviate(Math.abs(d["Population"]))}]
+    ]
+  },
+  x: "Population",
+  xConfig: {
+    tickFormat: function(d) {
+      return formatAbbreviate(Math.abs(d))
+    }
+  },
+  y: "Age range"
+};

--- a/charts/BarChart.stories.js
+++ b/charts/BarChart.stories.js
@@ -107,7 +107,6 @@ PercentStackedBarChart.args = {
   data: "https://datamexico.org/api/data?Indicator=107&Nation=mex&cube=indicators_economic_census&drilldowns=Category,Indicator,Sector&measures=Percentage&parents=false&locale=en",
   groupBy: ["Category"],
   discrete: "y",
-  height: 600,
   legendPosition: "bottom",
   stacked: true,
   x: "Percentage",
@@ -362,7 +361,6 @@ PopulationPyramid.args = {
     }
   ],
   groupBy: ["Sex"],
-  height: 400,
   discrete: "y",
   shapeConfig: {
     label: function(d) {return ""}

--- a/charts/BoxWhisker.args.js
+++ b/charts/BoxWhisker.args.js
@@ -2,30 +2,22 @@ import React from "react";
 import { argTypes as plotArgTypes } from "./Plot.args";
 import { assign } from "d3plus-common";
 
-import { AreaPlot as D3plusArea } from "d3plus-react";
-export const Area = ({ config }) => <D3plusArea config={config} />;
+import { BoxWhisker as D3plusBoxWhisker } from "d3plus-react";
+export const BoxWhisker = ({ config }) => <D3plusBoxWhisker config={config} />;
 
 export const argTypes = assign(
 
   /**
    * Filters out unused argTypes from the Plot args and
-   * overrides any defaults that have been changed in AreaPlot
+   * overrides any defaults that have been changed in BoxWhisker
    */
   Object.keys(plotArgTypes)
     .reduce((obj, k) => (obj[k] = plotArgTypes[k], obj), {}),
 
   /**
-   * Area-specific methods
+   * BoxWhisker-specific methods
    */
   {
-    baseline: {
-      defaultValue: 0,
-      table: {
-        defaultValue: {
-          summary: 0
-        }
-      }
-    },
     discrete: {
       defaultValue: "x",
       table: {
@@ -37,7 +29,7 @@ export const argTypes = assign(
     shape: {
       table: {
         defaultValue: {
-          summary: "Area"
+          summary: "Box"
         }
       }
     },

--- a/charts/BoxWhisker.stories.js
+++ b/charts/BoxWhisker.stories.js
@@ -1,0 +1,187 @@
+import React from 'react';
+import {argTypes, BoxWhisker} from './BoxWhisker.args';
+import configify from "../helpers/configify";
+
+export default {
+  title: "Charts/BoxWhisker",
+  component: BoxWhisker,
+  argTypes
+};
+
+const Template = (args) => <BoxWhisker config={configify(args, argTypes)} />;
+
+export const GettingStarted = Template.bind({});
+GettingStarted.args = {
+  data: [
+    {id: "alpha", value: 300},
+    {id: "alpha", value: 20},
+    {id: "alpha", value: 180},
+    {id: "alpha", value: 40},
+    {id: "alpha", value: 170},
+    {id: "alpha", value: 125},
+    {id: "alpha", value: 74},
+    {id: "alpha", value: 80},
+    {id: "beta", value: 180},
+    {id: "beta", value: 30},
+    {id: "beta", value: 120},
+    {id: "beta", value: 50},
+    {id: "beta", value: 140},
+    {id: "beta", value: 115},
+    {id: "beta", value: 14},
+    {id: "beta", value: 30}
+  ],
+  groupBy: ["id", "value"],
+  legend: false,
+  x: "id",
+  y: "value"
+};
+
+export const BoxAndWhiskerChartWithOutliers = Template.bind({});
+BoxAndWhiskerChartWithOutliers.args = {
+  data: [
+    {id: "alpha", value: 840},
+    {id: "alpha", value: 940},
+    {id: "alpha", value: 780},
+    {id: "alpha", value: 650},
+    {id: "alpha", value: 720},
+    {id: "alpha", value: 430},
+    {id: "alpha", value: 1850},
+    {id: "alpha", value: 300},
+    {id: "alpha", value: 360},
+    {id: "alpha", value: 1690},
+    {id: "alpha", value: 690},
+    {id: "alpha", value: -950},
+    {id: "alpha", value: -600},
+    {id: "alpha", value: -850},
+    {id: "beta", value: 980},
+    {id: "beta", value: 300},
+    {id: "beta", value: 120},
+    {id: "beta", value: 500},
+    {id: "beta", value: 140},
+    {id: "beta", value: 115},
+    {id: "beta", value: 14},
+    {id: "beta", value: -30},
+    {id: "beta", value: -1050},
+    {id: "beta", value: -100},
+    {id: "beta", value: -800},
+    {id: "beta", value: -1100}
+  ],
+  groupBy: ["id", "value"],
+  legend: false,
+  x: "id",
+  y: "value"
+};
+
+export const ChangingBoxAndWhiskerEndpointShapes = Template.bind({});
+ChangingBoxAndWhiskerEndpointShapes.args = {
+  data: [
+    {id: "alpha", value: 300},
+    {id: "alpha", value: 20},
+    {id: "alpha", value: 180},
+    {id: "alpha", value: 40},
+    {id: "alpha", value: 170},
+    {id: "alpha", value: 125},
+    {id: "alpha", value: 74},
+    {id: "alpha", value: 80},
+    {id: "beta",  value: 180},
+    {id: "beta",  value: 30},
+    {id: "beta",  value: 120},
+    {id: "beta",  value: 50},
+    {id: "beta",  value: 140},
+    {id: "beta",  value: 115},
+    {id: "beta",  value: 14},
+    {id: "beta",  value: 30},
+  ],
+  groupBy: ["id", "value"],
+  legend: false,
+  shapeConfig: {
+    whiskerConfig: {
+      endpoint: function(d) {
+        return d.id === "alpha" ? "Rect" : "Circle"
+      }
+    }
+  },
+  x: "id",
+  y: "value"
+};
+
+export const ChangingBoxAndWhiskerOutlierStyles = Template.bind({});
+ChangingBoxAndWhiskerOutlierStyles.args = {
+  data: [
+    {id: "alpha", value: 840},
+    {id: "alpha", value: 940},
+    {id: "alpha", value: 780},
+    {id: "alpha", value: 650},
+    {id: "alpha", value: 720},
+    {id: "alpha", value: 430},
+    {id: "alpha", value: 1850},
+    {id: "alpha", value: 300},
+    {id: "alpha", value: 360},
+    {id: "alpha", value: 1690},
+    {id: "alpha", value: 690},
+    {id: "alpha", value: -950},
+    {id: "alpha", value: -600},
+    {id: "alpha", value: -850},
+    {id: "beta", value: 980},
+    {id: "beta", value: 300},
+    {id: "beta", value: 120},
+    {id: "beta", value: 500},
+    {id: "beta", value: 140},
+    {id: "beta", value: 115},
+    {id: "beta", value: 14},
+    {id: "beta", value: -30},
+    {id: "beta", value: -1050},
+    {id: "beta", value: -100},
+    {id: "beta", value: -800},
+    {id: "beta", value: -1100}
+  ],
+  groupBy: ["id", "value"],
+  legend: false,
+  shapeConfig: {
+    outlier: function(d) {
+      return d.id === "alpha" ? "Circle" : "Rect";
+    },
+    outlierConfig: {
+      Rect: {
+        fill: "green"
+      },
+      Circle: {
+        fill: "red"
+      }
+    }
+  },
+  x: "id",
+  y: "value"
+};
+
+export const HorizontalBoxAndWhiskerChart = Template.bind({});
+HorizontalBoxAndWhiskerChart.args = {
+  data: [
+    {id: "alpha", value: 300},
+    {id: "alpha", value:  20},
+    {id: "alpha", value: 180},
+    {id: "alpha", value:  40},
+    {id: "alpha", value: 170},
+    {id: "alpha", value: 125},
+    {id: "alpha", value:  74},
+    {id: "alpha", value:  80},
+    {id: "beta",  value: 180},
+    {id: "beta",  value:  30},
+    {id: "beta",  value: 120},
+    {id: "beta",  value:  50},
+    {id: "beta",  value: 140},
+    {id: "beta",  value: 115},
+    {id: "beta",  value:  14},
+    {id: "beta",  value:  30}
+  ],
+  groupBy: ["id", "value"],
+  discrete: "y",
+  legend: false,
+  shapeConfig: {
+    Box: {
+      orient: "horizontal"
+    }
+  },
+  x: "value",
+  y: "id"
+};

--- a/charts/BumpChart.args.js
+++ b/charts/BumpChart.args.js
@@ -1,0 +1,116 @@
+import React from "react";
+import { argTypes as plotArgTypes } from "./Plot.args";
+import { assign } from "d3plus-common";
+
+import { BumpChart as D3plusBumpChart } from "d3plus-react";
+export const BumpChart = ({ config }) => <D3plusBumpChart config={config} />;
+
+export const argTypes = assign(
+
+  /**
+   * Filters out unused argTypes from the Plot args and
+   * overrides any defaults that have been changed in BumpChart
+   */
+  Object.keys(plotArgTypes)
+    .reduce((obj, k) => (obj[k] = plotArgTypes[k], obj), {}),
+
+  /**
+   * BumpChart-specific methods
+   */
+  {
+    discrete: {
+      defaultValue: "x",
+      table: {
+        defaultValue: {
+          summary: "x"
+        }
+      }
+    },
+    shape: {
+      defaultValue: "Line",
+      table: {
+        defaultValue: {
+          summary: "Line"
+        }
+      }
+    },
+    x: {
+      defaultValue: "x",
+      table: {
+        defaultValue: {
+          summary: "x"
+        }
+      }
+    },
+    yConfig: {
+      defaultValue: {
+        tickFormat: function (val) {
+          const data = this.formattedData;
+          const xMin = data[0].x instanceof Date ? data[0].x.getTime() : data[0].x;
+          const startData = data.filter(d => (d.x instanceof Date ? d.x.getTime() : d.x) === xMin);
+          const d = startData.find(d => d.y === val);
+
+          return d ? this._drawLabel(d, d.i) : "";
+        }
+      },
+      table: {
+        defaultValue: {
+          summary: "object"
+        }
+      }
+    },
+    ySort: {
+      defaultValue: function (a, b) {
+        return this._y(b) - this._y(a);
+      },
+      table: {
+        defaultValue: {
+          summary: "function",
+          defaultValue: `function(a, b) {
+            return this._y(b) - this._y(a);
+          }`
+        }
+      }
+    },
+    y2: {
+      defaultValue: function (d) {
+        return this._y(d)
+      },
+      table: {
+        defaultValue: {
+          summary: "function"
+        }
+      }
+    },
+    y2Config: {
+      defaultValue: {
+        tickFormat: function (val) {
+          const data = this._formattedData;
+          const xMax = data[data.length - 1].x instanceof Date ? data[data.length - 1].x.getTime() : data[data.length - 1].x;
+          const endData = data.filter(d => (d.x instanceof Date ? d.x.getTime() : d.x) === xMax);
+          const d = endData.find(d => d.y === val);
+
+          return d ? this._drawLabel(d, d.i) : "";
+        }
+      },
+      table: {
+        defaultValue: {
+          summary: "object"
+        }
+      }
+    },
+    y2Sort: {
+      defaultValue: function (a, b) {
+        return this._y(b) - this._y(a);
+      },
+      table: {
+        defaultValue: {
+          summary: "function",
+          defaultValue: `function(a, b) {
+  return this._y(b) - this._y(a);
+}`
+        }
+      }
+    }
+  }
+);

--- a/charts/BumpChart.stories.js
+++ b/charts/BumpChart.stories.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import {argTypes, BumpChart} from './BumpChart.args';
+import configify from "../helpers/configify";
+
+import {formatAbbreviate} from 'd3plus-format';
+
+export default {
+  title: "Charts/BumpChart",
+  component: BumpChart,
+  argTypes
+};
+
+const Template = (args) => <BumpChart config={configify(args, argTypes)} />;
+
+export const GettingStarted = Template.bind({});
+GettingStarted.args = {
+  data: [
+    {fruit: "apple", label: "Apple", year: 1, rank: 1},
+    {fruit: "apple", label: "Apple", year: 2, rank: 2},
+    {fruit: "apple", label: "Apple", year: 3, rank: 1},
+    {fruit: "banana", label: "Banana", year: 1, rank: 2},
+    {fruit: "banana", label: "Banana", year: 2, rank: 4},
+    {fruit: "banana", label: "Banana", year: 3, rank: 3},
+    {fruit: "cherry", label: "Cherry", year: 1, rank: 4},
+    {fruit: "cherry", label: "Cherry", year: 2, rank: 3},
+    {fruit: "cherry", label: "Cherry", year: 3, rank: 2},
+    {fruit: "orange", label: "Orange", year: 1, rank: 3},
+    {fruit: "orange", label: "Orange", year: 2, rank: 1},
+    {fruit: "orange", label: "Orange", year: 3, rank: 4}
+  ],
+  groupBy: "fruit",
+  discrete: "x",
+  label: function(d) {
+    return d["label"]
+  },
+  x: "year",
+  y: "rank",
+  y2: "rank"
+};

--- a/charts/Donut.args.js
+++ b/charts/Donut.args.js
@@ -1,28 +1,26 @@
 import React from "react";
-import {argTypes as pieArgTypes} from "./Pie.args";
+import { argTypes as pieArgTypes } from "./Pie.args";
+import { assign } from "d3plus-common";
 
-import {Donut as D3plusDonut} from "d3plus-react";
-export const Donut = ({config}) => <D3plusDonut config={config} />;
+import { Donut as D3plusDonut } from "d3plus-react";
+export const Donut = ({ config }) => <D3plusDonut config={config} />;
 
-export const argTypes = {
+export const argTypes = assign(
 
-    /**
-     * Filters out unused argTypes from the Pie args and
-     * overrides any defaults that have been changed in Donut
-     */
-    ...Object.keys(pieArgTypes)
-      .reduce((obj, k) => (obj[k] = pieArgTypes[k], obj), {}),
-  
-    /**
-     * Donnut-specific methods
-     */ 
+  /**
+   * Filters out unused argTypes from the Pie args and
+   * overrides any defaults that have been changed in Donut
+   */
+  Object.keys(pieArgTypes)
+    .reduce((obj, k) => (obj[k] = pieArgTypes[k], obj), {}),
+
+  /**
+   * Donut-specific methods
+   */
+  {
     innerRadius: {
-      type: {
-        summary: "function | number"
-      },
       table: {
         defaultValue: {
-          summary: "function | number",
           detail: `
           import {min} from "d3-array";
 
@@ -33,24 +31,14 @@ function innerRadius() {
   ]) / 4;
 }`
         }
-      },
-      description: `The function or value to be used as inner radius in the Pie.`
+      }
     },
     padPixel: {
-      type: {
-        summary: "number"
-      },
+      defaultValue: 2,
       table: {
-        defaultValue: {
-          summary: "number",
-          detail: "2"
-        }
-      },
-      control: {type: "number"},
-      description: `The arc padding to the specified pixel value.
-      
-By default the value is \`2\`, setting a small padding between each arc.
-
-If \`padAngle\` is defined, \`padPixel\` value will not be considered.`
+        summary: "number",
+        detail: 2
+      }
     }
   }
+);

--- a/charts/LinePlot.args.js
+++ b/charts/LinePlot.args.js
@@ -2,30 +2,22 @@ import React from "react";
 import { argTypes as plotArgTypes } from "./Plot.args";
 import { assign } from "d3plus-common";
 
-import { AreaPlot as D3plusArea } from "d3plus-react";
-export const Area = ({ config }) => <D3plusArea config={config} />;
+import { LinePlot as D3plusLinePlot } from "d3plus-react";
+export const LinePlot = ({ config }) => <D3plusLinePlot config={config} />;
 
 export const argTypes = assign(
 
   /**
    * Filters out unused argTypes from the Plot args and
-   * overrides any defaults that have been changed in AreaPlot
+   * overrides any defaults that have been changed in LinePlot
    */
   Object.keys(plotArgTypes)
     .reduce((obj, k) => (obj[k] = plotArgTypes[k], obj), {}),
 
   /**
-   * Area-specific methods
+   * LinePlot-specific methods
    */
   {
-    baseline: {
-      defaultValue: 0,
-      table: {
-        defaultValue: {
-          summary: 0
-        }
-      }
-    },
     discrete: {
       defaultValue: "x",
       table: {
@@ -35,17 +27,10 @@ export const argTypes = assign(
       }
     },
     shape: {
+      defaultValue: "Line",
       table: {
         defaultValue: {
-          summary: "Area"
-        }
-      }
-    },
-    x: {
-      defaultValue: "x",
-      table: {
-        defaultValue: {
-          summary: "x"
+          summary: "Line"
         }
       }
     }

--- a/charts/LinePlot.stories.js
+++ b/charts/LinePlot.stories.js
@@ -1,0 +1,564 @@
+import React from 'react';
+import { argTypes, LinePlot } from './LinePlot.args';
+import configify from "../helpers/configify";
+
+export default {
+  title: "Charts/LinePlot",
+  component: LinePlot,
+  argTypes
+};
+
+const Template = (args) => <LinePlot config={configify(args, argTypes)} />;
+
+export const GettingStarted = Template.bind({});
+GettingStarted.args = {
+  data: [
+    { id: "alpha", x: 4, y: 7 },
+    { id: "alpha", x: 5, y: 25 },
+    { id: "alpha", x: 6, y: 13 },
+    { id: "beta", x: 4, y: 17 },
+    { id: "beta", x: 5, y: 8 },
+    { id: "beta", x: 6, y: 13 }
+  ],
+  groupBy: "id",
+  x: "x",
+  y: "y"
+};
+
+export const AddingLabelsToLinePlot = Template.bind({});
+AddingLabelsToLinePlot.args = {
+  data: [
+    { id: "alpha", x: 4, y: 9 },
+    { id: "alpha", x: 5, y: 17 },
+    { id: "alpha", x: 6, y: 13 },
+    { id: "beta", x: 4, y: 17 },
+    { id: "beta", x: 5, y: 8 },
+    { id: "beta", x: 6, y: 16 },
+    { id: "gamma", x: 4, y: 14 },
+    { id: "gamma", x: 5, y: 9 },
+    { id: "gamma", x: 6, y: 11 }
+  ],
+  groupBy: "id",
+  lineLabels: true,
+  x: "x",
+  y: "y"
+};
+
+export const AddingLastValueLabelToLinePlot = Template.bind({});
+AddingLastValueLabelToLinePlot.args = {
+  data: [
+    { id: "alpha", x: 4, y: 9 },
+    { id: "alpha", x: 5, y: 17 },
+    { id: "alpha", x: 6, y: 13 },
+    { id: "beta", x: 4, y: 17 },
+    { id: "beta", x: 5, y: 8 },
+    { id: "beta", x: 6, y: 16 },
+    { id: "gamma", x: 4, y: 14 },
+    { id: "gamma", x: 5, y: 9 },
+    { id: "gamma", x: 6, y: 11 }
+  ],
+  groupBy: "id",
+  lineLabels: true,
+  shapeConfig: {
+    Line: {
+      label(d) {
+        const dataArray = this._filteredData.filter(f => f.id === d.id);
+        const maxX = Math.max(...dataArray.map(f => f.x));
+        const maxData = dataArray.find(f => f.x === maxX);
+
+        return `${maxData.y}`;
+      }
+    }
+  },
+  x: "x",
+  y: "y"
+};
+
+export const AddingVertexMarkersToLinePlot = Template.bind({});
+AddingVertexMarkersToLinePlot.args = {
+  data: [
+    { id: "alpha", x: 4, y: 9 },
+    { id: "alpha", x: 5, y: 17 },
+    { id: "alpha", x: 6, y: 13 },
+    { id: "beta", x: 4, y: 17 },
+    { id: "beta", x: 5, y: 8 },
+    { id: "beta", x: 6, y: 16 },
+    { id: "gamma", x: 4, y: 14 },
+    { id: "gamma", x: 5, y: 9 },
+    { id: "gamma", x: 6, y: 11 }
+  ],
+  groupBy: "id",
+  lineMarkers: true,
+  lineMarkerConfig: {
+    r: 6
+  },
+  x: "x",
+  y: "y"
+};
+
+export const ChangingLinePlotSplining = Template.bind({});
+ChangingLinePlotSplining.args = {
+  data: [
+    { fruit: "apple", price: 5, year: 2014 },
+    { fruit: "banana", price: 4, year: 2014 },
+    { fruit: "apple", price: 7, year: 2015 },
+    { fruit: "banana", price: 6, year: 2015 },
+    { fruit: "apple", price: 10, year: 2016 },
+    { fruit: "banana", price: 8, year: 2016 },
+    { fruit: "apple", price: 6, year: 2017 },
+    { fruit: "banana", price: 10, year: 2017 },
+    { fruit: "apple", price: 8, year: 2018 },
+    { fruit: "banana", price: 15, year: 2018 }
+  ],
+  groupBy: "fruit",
+  shapeConfig: {
+    Line: {
+      curve: "catmullRom"
+    }
+  },
+  x: "year",
+  y: "price"
+};
+
+export const ChangingTheStrokeWidthOfALinePlot = Template.bind({});
+ChangingTheStrokeWidthOfALinePlot.args = {
+  data: [
+    { id: "alpha", x: 4, y: 7 },
+    { id: "alpha", x: 5, y: 25 },
+    { id: "alpha", x: 6, y: 13 },
+    { id: "beta", x: 4, y: 17 },
+    { id: "beta", x: 5, y: 8 },
+    { id: "beta", x: 6, y: 13 }
+  ],
+  groupBy: "id",
+  shapeConfig: {
+    Line: {
+      strokeWidth: 5
+    }
+  },
+  x: "x",
+  y: "y"
+};
+
+export const ConfidenceInterval = Template.bind({});
+ConfidenceInterval.args = {
+  data: [
+    { fruit: "apple", year: 1, amount: 50, moe: 2 },
+    { fruit: "apple", year: 2, amount: 56, moe: 1 },
+    { fruit: "apple", year: 3, amount: 58, moe: 1 },
+    { fruit: "banana", year: 1, amount: 88, moe: 3 },
+    { fruit: "banana", year: 2, amount: 90, moe: 4 },
+    { fruit: "banana", year: 3, amount: 76, moe: 3 }
+  ],
+  groupBy: "fruit",
+  confidence: [
+    function (d) {
+      return d.amount - d.moe;
+    },
+    function (d) {
+      return d.amount + d.moe;
+    }
+  ],
+  confidenceConfig: {
+    fillOpacity: 0.3
+  },
+  x: "year",
+  y: "amount"
+};
+
+export const CustomDashLinePlot = Template.bind({});
+CustomDashLinePlot.args = {
+  data: [
+    { fruit: "apple", price: 5, year: 2014 },
+    { fruit: "banana", price: 4, year: 2014 },
+    { fruit: "cherry", price: 7, year: 2014 },
+    { fruit: "apple", price: 7, year: 2015 },
+    { fruit: "banana", price: 6, year: 2015 },
+    { fruit: "cherry", price: 9, year: 2015 },
+    { fruit: "apple", price: 10, year: 2016 },
+    { fruit: "banana", price: 8, year: 2016 },
+    { fruit: "cherry", price: 5, year: 2016 },
+    { fruit: "apple", price: 6, year: 2017 },
+    { fruit: "banana", price: 10, year: 2017 },
+    { fruit: "cherry", price: 10, year: 2017 },
+    { fruit: "apple", price: 8, year: 2018 },
+    { fruit: "banana", price: 15, year: 2018 },
+    { fruit: "cherry", price: 12, year: 2018 }
+  ],
+  groupBy: "fruit",
+  shapeConfig: {
+    Line: {
+      strokeDasharray: function (d) {
+        if (d.fruit === "apple") return "10";
+        if (d.fruit === "banana") return "10 7 3";
+        if (d.fruit === "cherry") return "10 7 5 2";
+        return "0";
+      }
+    }
+  },
+  x: "year",
+  y: "price"
+};
+
+export const DashedLinePlot = Template.bind({});
+DashedLinePlot.args = {
+  data: [
+    { fruit: "apple", price: 5, year: 2014 },
+    { fruit: "banana", price: 4, year: 2014 },
+    { fruit: "cherry", price: 7, year: 2014 },
+    { fruit: "apple", price: 7, year: 2015 },
+    { fruit: "banana", price: 6, year: 2015 },
+    { fruit: "cherry", price: 9, year: 2015 },
+    { fruit: "apple", price: 10, year: 2016 },
+    { fruit: "banana", price: 8, year: 2016 },
+    { fruit: "cherry", price: 5, year: 2016 },
+    { fruit: "apple", price: 6, year: 2017 },
+    { fruit: "banana", price: 10, year: 2017 },
+    { fruit: "cherry", price: 10, year: 2017 },
+    { fruit: "apple", price: 8, year: 2018 },
+    { fruit: "banana", price: 15, year: 2018 },
+    { fruit: "cherry", price: 12, year: 2018 }
+  ],
+  groupBy: "fruit",
+  shapeConfig: {
+    Line: {
+      strokeDasharray: "10"
+    }
+  },
+  x: "year",
+  y: "price"
+};
+
+export const LinePlotCustomColor = Template.bind({});
+LinePlotCustomColor.args = {
+  data: [
+    { fruit: "apple", price: 5, year: 2014 },
+    { fruit: "banana", price: 4, year: 2014 },
+    { fruit: "cherry", price: 7, year: 2014 },
+    { fruit: "apple", price: 7, year: 2015 },
+    { fruit: "banana", price: 6, year: 2015 },
+    { fruit: "cherry", price: 9, year: 2015 },
+    { fruit: "apple", price: 10, year: 2016 },
+    { fruit: "banana", price: 8, year: 2016 },
+    { fruit: "cherry", price: 5, year: 2016 },
+    { fruit: "apple", price: 6, year: 2017 },
+    { fruit: "banana", price: 10, year: 2017 },
+    { fruit: "cherry", price: 10, year: 2017 },
+    { fruit: "apple", price: 8, year: 2018 },
+    { fruit: "banana", price: 15, year: 2018 },
+    { fruit: "cherry", price: 12, year: 2018 }
+  ],
+  groupBy: "fruit",
+  shapeConfig: {
+    Line: {
+      stroke: function (d) {
+        if (d.fruit === "apple") return "green";
+        if (d.fruit === "banana") return "goldenrod";
+        if (d.fruit === "cherry") return "red";
+        return "grey";
+      }
+    }
+  },
+  x: "year",
+  y: "price"
+};
+
+export const LinePlotSorting = Template.bind({});
+LinePlotSorting.args = {
+  data: [
+    { fruit: "apple", price: 5, year: 2014 },
+    { fruit: "banana", price: 4, year: 2014 },
+    { fruit: "apple", price: 7, year: 2015 },
+    { fruit: "banana", price: 6, year: 2015 },
+    { fruit: "apple", price: 10, year: 2016 },
+    { fruit: "banana", price: 8, year: 2016 },
+    { fruit: "apple", price: 6, year: 2017 },
+    { fruit: "banana", price: 10, year: 2017 },
+    { fruit: "apple", price: 8, year: 2018 },
+    { fruit: "banana", price: 15, year: 2018 }
+  ],
+  groupBy: "fruit",
+  shapeConfig: {
+    Line: {
+      strokeLinecap: "round",
+      strokeWidth: 10
+    },
+    sort: function (a, b) {
+      if (a.fruit === "apple") return 1;
+      else return -1;
+    }
+  },
+  x: "year",
+  y: "price"
+};
+
+export const PredictionsLinePlot = Template.bind({});
+PredictionsLinePlot.args = {
+  data: [
+    {
+      "Year": 2006,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 227746107622,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2006,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 243328728338,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2007,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 250510781866,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2007,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 266075508173,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2008,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 273451264785,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2008,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 284982624365,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2009,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 206734904705,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2009,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 220133846133,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2010,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 282348541534,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2010,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 293914911217,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2011,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 331884428040,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2011,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 343550107823,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2012,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 351687026850,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2012,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 361886624083,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2013,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 356069934491,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2013,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 373619307190,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2014,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 369627996773,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2014,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 389499264277,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2015,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 375484880972,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2015,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 372557671308,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2016,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 363829206796,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2016,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 364493560621,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2017,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 376297646785,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2017,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 401741532115,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2018,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 414829536859,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2018,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 441736801029,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2019,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 425699639802,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2019,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 432693158563,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2020,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 366314124058,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2020,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 406070750072,
+      "Type": "Observed"
+    },
+    {
+      "Year": 2020,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 366314124058,
+      "Type": "Predicted"
+    },
+    {
+      "Year": 2020,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 406070750072,
+      "Type": "Predicted"
+    },
+    {
+      "Year": 2021,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 346314124058,
+      "Type": "Predicted"
+    },
+    {
+      "Year": 2021,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 386070750072,
+      "Type": "Predicted"
+    },
+    {
+      "Year": 2022,
+      "Flow ID": 1,
+      "Flow": "Imports",
+      "Trade Value": 336314124058,
+      "Type": "Predicted"
+    },
+    {
+      "Year": 2022,
+      "Flow ID": 2,
+      "Flow": "Exports",
+      "Trade Value": 396070750072,
+      "Type": "Predicted"
+    }
+  ],
+  groupBy: ["Type", "Flow"],
+  shapeConfig: {
+    Line: {
+      strokeDasharray: function (d) {
+        if (d["Type"] === "Predicted") return "10";
+        return "0";
+      }
+    }
+  },
+  time: "Year",
+  timeline: false,
+  x: "Year",
+  y: "Trade Value"
+};

--- a/charts/LinePlot.stories.js
+++ b/charts/LinePlot.stories.js
@@ -74,6 +74,87 @@ AddingLastValueLabelToLinePlot.args = {
   y: "y"
 };
 
+export const AddingSecondaryYAxis = Template.bind({});
+AddingSecondaryYAxis.args = {
+  data: [
+    {
+      "Country ID": "nausa",
+      "Country": "United States",
+      "Year": 2011,
+      "Trade Value": 1403273708182,
+      "Trade Value Growth": 0.17509765715100706
+    },
+    {
+      "Country ID": "nausa",
+      "Country": "United States",
+      "Year": 2012,
+      "Trade Value": 1453520657725,
+      "Trade Value Growth": 0.03580694860170724
+    },
+    {
+      "Country ID": "nausa",
+      "Country": "United States",
+      "Year": 2013,
+      "Trade Value": 1478035757057,
+      "Trade Value Growth": 0.016866013703836988
+    },
+    {
+      "Country ID": "nausa",
+      "Country": "United States",
+      "Year": 2014,
+      "Trade Value": 1521969928619,
+      "Trade Value Growth": 0.029724701416885744
+    },
+    {
+      "Country ID": "nausa",
+      "Country": "United States",
+      "Year": 2015,
+      "Trade Value": 1409516953687,
+      "Trade Value Growth": -0.07388646307488954
+    },
+    {
+      "Country ID": "nausa",
+      "Country": "United States",
+      "Year": 2016,
+      "Trade Value": 1353648792022,
+      "Trade Value Growth": -0.0396363885647921
+    },
+    {
+      "Country ID": "nausa",
+      "Country": "United States",
+      "Year": 2017,
+      "Trade Value": 1456201053251,
+      "Trade Value Growth": 0.07575987348669187
+    },
+    {
+      "Country ID": "nausa",
+      "Country": "United States",
+      "Year": 2018,
+      "Trade Value": 1548849519602,
+      "Trade Value Growth": 0.06362340292513889
+    },
+    {
+      "Country ID": "nausa",
+      "Country": "United States",
+      "Year": 2019,
+      "Trade Value": 1511931053052,
+      "Trade Value Growth": -0.023836057720756986
+    }
+  ],
+  groupBy: ["Country"],
+  shape: "Line",
+  x: "Year",
+  xConfig: {
+    labels: [2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019],
+    tickFormat: function (d) { return `${d * 1}` }
+  },
+  y: "Trade Value",
+  y2: "Trade Value Growth",
+  y2Config: {
+    tickFormat: function (d) { return `${parseInt(d * 100)}%` }
+  }
+};
+
 export const AddingVertexMarkersToLinePlot = Template.bind({});
 AddingVertexMarkersToLinePlot.args = {
   data: [

--- a/charts/Pie.args.js
+++ b/charts/Pie.args.js
@@ -1,22 +1,24 @@
 import React from "react";
 import Viz from "../primitives/Viz";
+import { assign } from "d3plus-common";
 
-import {Pie as D3plusPie} from "d3plus-react";
-export const Pie = ({config}) => <D3plusPie config={config} />;
+import { Pie as D3plusPie } from "d3plus-react";
+export const Pie = ({ config }) => <D3plusPie config={config} />;
 
-export const argTypes = {
+export const argTypes = assign(
 
-    /**
-     * Filters out unused argTypes from the Viz primitive and
-     * overrides any defaults that have been changed in Pie
-     */
-    ...Object.keys(Viz.argTypes)
-      .filter(k => !k.match(/^(discrete|shape|zoom.*)$/))
-      .reduce((obj, k) => (obj[k] = Viz.argTypes[k], obj), {}),
-  
-    /**
-     * Pie-specific methods
-     */
+  /**
+   * Filters out unused argTypes from the Viz primitive and
+   * overrides any defaults that have been changed in Pie
+   */
+  Object.keys(Viz.argTypes)
+    .filter(k => !k.match(/^(discrete|shape|zoom.*)$/))
+    .reduce((obj, k) => (obj[k] = Viz.argTypes[k], obj), {}),
+
+  /**
+   * Pie-specific methods
+   */
+  {
     innerRadius: {
       type: {
         summary: "function | number"
@@ -27,7 +29,7 @@ export const argTypes = {
           summary: 0
         }
       },
-      control: {type: "number"},
+      control: { type: "number" },
       description: `The pixel value, or function that returns a pixel value, that is used as the inner radius of the Pie (creating a Donut).`
     },
     padAngle: {
@@ -39,7 +41,7 @@ export const argTypes = {
           summary: "undefined",
         }
       },
-      control: {type: "number"},
+      control: { type: "number" },
       description: `The padding between each arc, set as a radian value between \`0\` and \`1\`.
       
 If set, this will override any previously set padPixel value.`
@@ -54,7 +56,7 @@ If set, this will override any previously set padPixel value.`
           summary: 0
         }
       },
-      control: {type: "number"},
+      control: { type: "number" },
       description: `The padding between each arc, set as a pixel number value.
       
 By default the value is \`0\`, which shows no padding between each arc.
@@ -71,7 +73,7 @@ If \`padAngle\` is defined, the \`padPixel\` value will not be considered.`
           detail: `(a, b) => b.value - a.value`
         }
       },
-      control: {type: null},
+      control: { type: null },
       description: `A comparator function that sorts the Pie slices.`
     },
     value: {
@@ -88,3 +90,4 @@ If \`padAngle\` is defined, the \`padPixel\` value will not be considered.`
       description: `The accessor key for each data point used to calculate the size of each Pie section.`
     }
   }
+);

--- a/charts/Plot.args.js
+++ b/charts/Plot.args.js
@@ -12,7 +12,7 @@ export const argTypes = {
      * overrides any defaults that have been changed in Plot
      */
     ...Object.keys(Viz.argTypes)
-      .filter(k => !k.match(/^(discrete|shape|zoom.*)$/))
+      .filter(k => !k.match(/^(discrete|zoom.*)$/))
       .reduce((obj, k) => (obj[k] = Viz.argTypes[k], obj), {}),
   
     /**
@@ -27,7 +27,7 @@ export const argTypes = {
           summary: "[]"
         }
       },
-      control: {type: "text"},
+      control: {type: "array"},
       description: `Allows drawing custom shapes to be used as annotations in the provided x/y plot. 
 
 This method accepts custom config objects for the [Shape](http://d3plus.org/docs/#Shape) class, either a single config object or an array of config objects. 
@@ -213,6 +213,16 @@ import {constant} from "d3plus-common";
       control: {type: "boolean"},
       description: `Draws circle markers on each vertex of a Line.`
     },
+    shape: {
+      table: {
+        defaultValue: {
+          summary: `Circle`
+        }
+      },
+      control: {
+        type: null
+      }
+    },
     shapeSort: {
       type: {
         summary: "function"
@@ -228,7 +238,7 @@ function shapeSort(a, b) {
           `
         }
       },
-      control: {type: "text"},
+      control: {type: null},
       description: `A comparator function that sorts the shapes based on their type.`
     },
     size: {

--- a/charts/Plot.args.js
+++ b/charts/Plot.args.js
@@ -57,7 +57,7 @@ Annotations will be drawn underneath the data to be displayed.`
         }
       },
       control: { type: "object" },
-      description: `A d3plus-shape configuration Object used for styling the background rectangle of the inner x/y plot (behind all of the shapes and gridlines).`
+      description: `A d3plus-shape config Object that is used for styling the background rectangle of the inner x/y plot.`
     },
     barPadding: {
       type: {
@@ -83,7 +83,7 @@ Annotations will be drawn underneath the data to be displayed.`
         }
       },
       control: { type: "number" },
-      description: `Sets the baseline for the x/y plot. If it is not specified, returns the current baseline.`
+      description: `Sets the baseline for the x/y plot.`
     },
     confidence: {
       type: {
@@ -293,7 +293,7 @@ function shapeSort(a, b) {
       },
       control: {
         type: "select",
-        options: ["identity", "linear", "log", "radial", "sqrt", "time"] // not sure about all of these options
+        options: ["identity", "linear", "log", "radial", "sqrt", "time"]
       },
       description: `Sets the size scale to the specified string.`
     },

--- a/charts/Plot.args.js
+++ b/charts/Plot.args.js
@@ -1,0 +1,575 @@
+import React from "react";
+import Viz from "../primitives/Viz";
+
+import {Plot as D3plusPlot} from "d3plus-react";
+
+export const Plot = ({config}) => <D3plusPlot config={config} />;
+
+export const argTypes = {
+
+    /**
+     * Filters out unused argTypes from the Viz primitive and
+     * overrides any defaults that have been changed in Plot
+     */
+    ...Object.keys(Viz.argTypes)
+      .filter(k => !k.match(/^(discrete|shape|zoom.*)$/))
+      .reduce((obj, k) => (obj[k] = Viz.argTypes[k], obj), {}),
+  
+    /**
+     * Plot-specific methods
+     */
+    annotations: {
+      type: {
+        summary: "array | object"
+      },
+      table: {
+        defaultValue: {
+          summary: "[]"
+        }
+      },
+      control: {type: "text"},
+      description: `Allows drawing custom shapes to be used as annotations in the provided x/y plot. 
+
+This method accepts custom config objects for the [Shape](http://d3plus.org/docs/#Shape) class, either a single config object or an array of config objects. 
+
+Each config object requires an additional parameter, the "shape", which denotes which [Shape](http://d3plus.org/docs/#Shape) sub-class to use ([Rect](http://d3plus.org/docs/#Rect), [Line](http://d3plus.org/docs/#Line), etc). 
+
+Annotations will be drawn underneath the data to be displayed.`
+    },
+    backgroundConfig: {
+      type: {
+        summary: "object"
+      },
+      defaultValue: {
+        duration: 0,
+        fill: "transparent"
+      },
+      table: {
+        defaultValue: {
+          summary: "object",
+          detail: `{
+  duration: 0,
+  fill: "transparent"
+}`
+        }
+      },
+      control: {type: "object"},
+      description: `A d3plus-shape configuration Object used for styling the background rectangle of the inner x/y plot (behind all of the shapes and gridlines).`
+    },
+    barPadding: {
+      type: {
+        summary: "number"
+      },
+      defaultValue: 0,
+      table: {
+        defaultValue: {
+          summary: 0
+        }
+      },
+      control: {type: "number"},
+      description: `Sets the pixel space between each bar in a group of bars.`
+    },
+    baseline: {
+      type: {
+        summary: "number"
+      },
+      defaultValue: "undefined",
+      table: {
+        defaultValue: {
+          summary: "undefined"
+        }
+      },
+      control: {type: "number"},
+      description: `Sets the baseline for the x/y plot. If it is not specified, returns the current baseline.`
+    },
+    confidence: {
+      type: {
+        summary: "string[] | function[]"
+      },
+      defaultValue: "undefined",
+      table: {
+        defaultValue: {
+          summary: "undefined"
+        }
+      },
+      control: {type: "text"},
+      description: `Sets the confidence to the specified array of lower and upper bounds.
+Can be called with accessor functions or static keys.
+
+Example:
+
+\`var data = {id: "alpha", value: 10, lci: 9, hci: 11};\`
+
+Accessor function
+
+\`confidence: d => [d.lci, d.hci]\`
+
+Static keys
+
+\`confidence: ["lci", "hci"]\`
+`
+    },
+    confidenceConfig: {
+      type: {
+        summary: "object"
+      },
+      defaultValue: "undefined",
+      table: {
+        defaultValue: {
+          summary: "undefined"
+        }
+      },
+      control: {type: "object"},
+      description: `Sets the config method for each shape rendered as a confidence interval`
+    },
+    discrete: {
+      type: {
+        summary: "string"
+      },
+      defaultValue: "x",
+      table: {
+        defaultValue: {
+          summary: "x"
+        }
+      },
+      control: {type: "object"},
+      description: `Sets the discrete axis to the specified string.`
+    },
+    discreteCutoff: {
+      type: {
+        summary: "number"
+      },
+      defaultValue: 100,
+      table: {
+        defaultValue: {
+          summary: 100
+        }
+      },
+      control: {type: "number"},
+      description: `When the width or height of the chart is less than or equal to this pixel value, the discrete axis will not be shown. 
+      
+This helps produce slick sparklines. 
+
+Set this value to \`0\` to disable the behavior entirely.`
+    },
+    groupPadding: {
+      type: {
+        summary: "number"
+      },
+      defaultValue: 5,
+      table: {
+        defaultValue: {
+          summary: 5
+        }
+      },
+      control: {type: "number"},
+      description: `Sets the pixel space between groups of bars.`
+    },
+    lineLabels: {
+      type: {
+        summary: "boolean"
+      },
+      defaultValue: false,
+      table: {
+        defaultValue: {
+          summary: false
+        }
+      },
+      control: {type: "boolean"},
+      description: `Draws labels on the right side of any Line shapes that are drawn on the plot.`
+    },
+    lineMarkerConfig: {
+      type: {
+        summary: "object"
+      },
+      defaultValue: false,
+      table: {
+        defaultValue: {
+          summary: "object",
+          detail: `import {colorAssign} from "d3plus-color";
+import {constant} from "d3plus-common";
+
+{
+  fill: function fill(d, i) {
+    return colorAssign(this._id(d, i))
+  },
+  r: constant(3)
+}`
+        }
+      },
+      control: {type: "object"},
+      description: `Shape config for the Circle shapes drawn by the lineMarkers method.`
+    },
+    lineMarkers: {
+      type: {
+        summary: "boolean"
+      },
+      defaultValue: false,
+      table: {
+        defaultValue: {
+          summary: false
+        }
+      },
+      control: {type: "boolean"},
+      description: `Draws circle markers on each vertex of a Line.`
+    },
+    shapeSort: {
+      type: {
+        summary: "function"
+      },
+      table: {
+        defaultValue: {
+          summary: "function",
+          detail: `const _shapeOrder = ["Area", "Path", "Bar", "Box", "Line", "Rect", "Circle"];
+
+function shapeSort(a, b) {
+  return _shapeOrder.indexOf(a) - _shapeOrder.indexOf(b)
+};
+          `
+        }
+      },
+      control: {type: "text"},
+      description: `A comparator function that sorts the shapes based on their type.`
+    },
+    size: {
+      type: {
+        summary: "function | number | string"
+      },
+      defaultValue: "undefined",
+      table: {
+        defaultValue: {
+          summary: "undefined"
+        }
+      },
+      control: {type: "text"},
+      description: `Sets the size of circles to the given number, data key, or function.`
+    },
+    sizeMax: {
+      type: {
+        summary: "number"
+      },
+      defaultValue: 20,
+      table: {
+        defaultValue: {
+          summary: 20
+        }
+      },
+      control: {type: "number"},
+      description: `Sets the size scale maximum to the specified number.`
+    },
+    sizeMin: {
+      type: {
+        summary: "number"
+      },
+      defaultValue: 5,
+      table: {
+        defaultValue: {
+          summary: 5
+        }
+      },
+      control: {type: "number"},
+      description: `Sets the size scale minimum to the specified number.`
+    },
+    sizeScale: {
+      type: {
+        summary: "string"
+      },
+      defaultValue: "sqrt",
+      table: {
+        defaultValue: {
+          summary: "sqrt"
+        }
+      },
+      control: {
+        type: "select",
+        options: ["identity", "linear", "log", "radial", "sqrt", "time"] // not sure about all of these options
+      },
+      description: `Sets the size scale to the specified string.`
+    },
+    stacked: {
+      type: {
+        summary: "boolean"
+      },
+      defaultValue: false,
+      table: {
+        defaultValue: {
+          summary: false
+        }
+      },
+      control: {type: "boolean"},
+      description: `Sets the shape stacking functionality.`
+    },
+    stackOffset: {
+      type: {
+        summary: "function | string"
+      },
+      defaultValue: "descending",
+      table: {
+        defaultValue: {
+          summary: "descending"
+        }
+      },
+      control: {type: "text"},
+      description: `Sets the stack offset.`
+    },
+    stackOrder: {
+      type: {
+        summary: "function | string | array"
+      },
+      defaultValue: "none",
+      table: {
+        defaultValue: {
+          summary: "none"
+        }
+      },
+      control: {type: "text"},
+      description: `Sets the stack order.`
+    },
+    x: {
+      type: {
+        summary: "function | number"
+      },
+      defaultValue: "x",
+      table: {
+        defaultValue: {
+          summary: "x"
+        }
+      },
+      control: {type: "text"},
+      description: `Sets the x accessor to the specified function or number.`
+    },
+    x2: {
+      type: {
+        summary: "function | number"
+      },
+      defaultValue: "x2",
+      table: {
+        defaultValue: {
+          summary: "x2"
+        }
+      },
+      control: {type: "text"},
+      description: `Sets the x2 accessor to the specified function or number.`
+    },
+    xConfig: {
+      type: {
+        summary: "object"
+      },
+      table: {
+        defaultValue: {
+          summary: "object",
+          detail: `import {range} from "d3-array";
+
+{
+  gridConfig: {
+    stroke: function stroke(d) {
+      if (this._discrete && this._discrete.charAt(0) === "x") return "transparent";
+      const range = this._xAxis.range();
+      return range[0] === this._xAxis._getPosition.bind(this._xAxis)(d.id) ? "transparent" : "#eee";
+    }
+  }
+}`
+        }
+      },
+      control: {type: "object"},
+      description: `A pass-through to the underlying [Axis](http://d3plus.org/docs/#Axis) config used for the x-axis.`
+    },
+    xCutoff: {
+      type: {
+        summary: "number"
+      },
+      defaultValue: 150,
+      table: {
+        defaultValue: {
+          summary: "undefined"
+        }
+      },
+      control: {type: "number"},
+      description: `When the width of the chart is less than or equal to this pixel value, and the x-axis is not the discrete axis, it will not be shown.`
+    },
+    x2Config: {
+      type: {
+        summary: "object"
+      },
+      table: {
+        defaultValue: {
+          summary: "object",
+          detail: `{
+  padding: 0
+}`
+        }
+      },
+      control: {type: "object"},
+      description: `A pass-through to the underlying [Axis](http://d3plus.org/docs/#Axis) config used for the x2-axis.`
+    },
+    xDomain: {
+      type: {
+        summary: "array"
+      },
+      table: {
+        defaultValue: {
+          summary: "undefined",
+        }
+      },
+      control: {type: "object"},
+      description: `Sets the x domain to the specified array.`
+    },
+    x2Domain: {
+      type: {
+        summary: "array"
+      },
+      table: {
+        defaultValue: {
+          summary: "undefined",
+        }
+      },
+      control: {type: "object"},
+      description: `Sets the x2 domain to the specified array.`
+    },
+    xSort: {
+      type: {
+        summary: "function"
+      },
+      table: {
+        defaultValue: {
+          summary: "undefined",
+        }
+      },
+      control: {type: "object"},
+      description: `A comparator function that custom sorts discrete x axis.`
+    },
+    x2Sort: {
+      type: {
+        summary: "function"
+      },
+      table: {
+        defaultValue: {
+          summary: "undefined",
+        }
+      },
+      control: {type: "object"},
+      description: `A comparator function that custom sorts discrete x2 axis.`
+    },
+    y: {
+      type: {
+        summary: "function | number"
+      },
+      defaultValue: "y",
+      table: {
+        defaultValue: {
+          summary: "y"
+        }
+      },
+      control: {type: "text"},
+      description: `Sets the y accessor to the specified function or number.`
+    },
+    y2: {
+      type: {
+        summary: "function | number"
+      },
+      defaultValue: "y2",
+      table: {
+        defaultValue: {
+          summary: "y2"
+        }
+      },
+      control: {type: "text"},
+      description: `Sets the y2 accessor to the specified function or number.`
+    },
+    yConfig: {
+      type: {
+        summary: "object"
+      },
+      table: {
+        defaultValue: {
+          summary: "object",
+          detail: `import {range} from "d3-array";
+
+{
+  gridConfig: {
+    stroke: function stroke(d) {
+      if (this._discrete && this._discrete.charAt(0) === "y") return "transparent";
+      const range = this._yAxis.range();
+      return range[0] === this._yAxis._getPosition.bind(this._yAxis)(d.id) ? "transparent" : "#eee";
+    }
+  }
+}`
+        }
+      },
+      control: {type: "object"},
+      description: `A pass-through to the underlying [Axis](http://d3plus.org/docs/#Axis) config used for the y-axis.`
+    },
+    yCutoff: {
+      type: {
+        summary: "number"
+      },
+      defaultValue: 150,
+      table: {
+        defaultValue: {
+          summary: 150
+        }
+      },
+      control: {type: "number"},
+      description: `When the width of the chart is less than or equal to this pixel value, and the y-axis is not the discrete axis, it will not be shown.`
+    },
+    y2Config: {
+      type: {
+        summary: "object"
+      },
+      table: {
+        defaultValue: {
+          summary: "{}",
+        }
+      },
+      control: {type: "object"},
+      description: `A pass-through to the underlying [Axis](http://d3plus.org/docs/#Axis) config used for the y2-axis.`
+    },
+    yDomain: {
+      type: {
+        summary: "array"
+      },
+      table: {
+        defaultValue: {
+          summary: "undefined",
+        }
+      },
+      control: {type: "object"},
+      description: `Sets the y domain to the specified array.`
+    },
+    y2Domain: {
+      type: {
+        summary: "array"
+      },
+      table: {
+        defaultValue: {
+          summary: "undefined",
+        }
+      },
+      control: {type: "object"},
+      description: `Sets the y2 domain to the specified array.`
+    },
+    ySort: {
+      type: {
+        summary: "function"
+      },
+      table: {
+        defaultValue: {
+          summary: "undefined",
+        }
+      },
+      control: {type: "object"},
+      description: `A comparator function that custom sorts discrete y axis.`
+    },
+    y2Sort: {
+      type: {
+        summary: "function"
+      },
+      table: {
+        defaultValue: {
+          summary: "undefined",
+        }
+      },
+      control: {type: "object"},
+      description: `A comparator function that custom sorts discrete y2 axis.`
+    }
+  }

--- a/charts/Plot.args.js
+++ b/charts/Plot.args.js
@@ -1,23 +1,26 @@
 import React from "react";
 import Viz from "../primitives/Viz";
+import { assign } from "d3plus-common";
 
-import {Plot as D3plusPlot} from "d3plus-react";
+import { Plot as D3plusPlot } from "d3plus-react";
+export const Plot = ({ config }) => <D3plusPlot config={config} />;
 
-export const Plot = ({config}) => <D3plusPlot config={config} />;
-
-export const argTypes = {
-
-    /**
-     * Filters out unused argTypes from the Viz primitive and
-     * overrides any defaults that have been changed in Plot
-     */
-    ...Object.keys(Viz.argTypes)
-      .filter(k => !k.match(/^(discrete|zoom.*)$/))
-      .reduce((obj, k) => (obj[k] = Viz.argTypes[k], obj), {}),
+export const argTypes = assign(
   
-    /**
-     * Plot-specific methods
-     */
+  /**
+   * Filters out unused argTypes from the Viz primitive and
+   * overrides any defaults that have been changed in Plot
+   */
+
+  Object.keys(Viz.argTypes)
+    .filter(k => !k.match(/^(discrete|zoom.*)$/))
+    .reduce((obj, k) => (obj[k] = Viz.argTypes[k], obj), {}),
+
+  /**
+   * Plot-specific methods
+   */
+  
+  {
     annotations: {
       type: {
         summary: "array | object"
@@ -27,7 +30,7 @@ export const argTypes = {
           summary: "[]"
         }
       },
-      control: {type: "array"},
+      control: { type: "array" },
       description: `Allows drawing custom shapes to be used as annotations in the provided x/y plot. 
 
 This method accepts custom config objects for the [Shape](http://d3plus.org/docs/#Shape) class, either a single config object or an array of config objects. 
@@ -53,7 +56,7 @@ Annotations will be drawn underneath the data to be displayed.`
 }`
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `A d3plus-shape configuration Object used for styling the background rectangle of the inner x/y plot (behind all of the shapes and gridlines).`
     },
     barPadding: {
@@ -66,7 +69,7 @@ Annotations will be drawn underneath the data to be displayed.`
           summary: 0
         }
       },
-      control: {type: "number"},
+      control: { type: "number" },
       description: `Sets the pixel space between each bar in a group of bars.`
     },
     baseline: {
@@ -79,7 +82,7 @@ Annotations will be drawn underneath the data to be displayed.`
           summary: "undefined"
         }
       },
-      control: {type: "number"},
+      control: { type: "number" },
       description: `Sets the baseline for the x/y plot. If it is not specified, returns the current baseline.`
     },
     confidence: {
@@ -92,7 +95,7 @@ Annotations will be drawn underneath the data to be displayed.`
           summary: "undefined"
         }
       },
-      control: {type: "text"},
+      control: { type: "text" },
       description: `Sets the confidence to the specified array of lower and upper bounds.
 Can be called with accessor functions or static keys.
 
@@ -119,7 +122,7 @@ Static keys
           summary: "undefined"
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `Sets the config method for each shape rendered as a confidence interval`
     },
     discrete: {
@@ -132,7 +135,7 @@ Static keys
           summary: "x"
         }
       },
-      control: {type: "object"},
+      control: { type: "text" },
       description: `Sets the discrete axis to the specified string.`
     },
     discreteCutoff: {
@@ -145,7 +148,7 @@ Static keys
           summary: 100
         }
       },
-      control: {type: "number"},
+      control: { type: "number" },
       description: `When the width or height of the chart is less than or equal to this pixel value, the discrete axis will not be shown. 
       
 This helps produce slick sparklines. 
@@ -162,7 +165,7 @@ Set this value to \`0\` to disable the behavior entirely.`
           summary: 5
         }
       },
-      control: {type: "number"},
+      control: { type: "number" },
       description: `Sets the pixel space between groups of bars.`
     },
     lineLabels: {
@@ -175,7 +178,7 @@ Set this value to \`0\` to disable the behavior entirely.`
           summary: false
         }
       },
-      control: {type: "boolean"},
+      control: { type: "boolean" },
       description: `Draws labels on the right side of any Line shapes that are drawn on the plot.`
     },
     lineMarkerConfig: {
@@ -197,7 +200,7 @@ import {constant} from "d3plus-common";
 }`
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `Shape config for the Circle shapes drawn by the lineMarkers method.`
     },
     lineMarkers: {
@@ -210,17 +213,15 @@ import {constant} from "d3plus-common";
           summary: false
         }
       },
-      control: {type: "boolean"},
+      control: { type: "boolean" },
       description: `Draws circle markers on each vertex of a Line.`
     },
     shape: {
+      defaultValue: "Circle",
       table: {
         defaultValue: {
-          summary: `Circle`
+          summary: "Circle"
         }
-      },
-      control: {
-        type: null
       }
     },
     shapeSort: {
@@ -238,7 +239,7 @@ function shapeSort(a, b) {
           `
         }
       },
-      control: {type: null},
+      control: { type: null },
       description: `A comparator function that sorts the shapes based on their type.`
     },
     size: {
@@ -251,7 +252,7 @@ function shapeSort(a, b) {
           summary: "undefined"
         }
       },
-      control: {type: "text"},
+      control: { type: "text" },
       description: `Sets the size of circles to the given number, data key, or function.`
     },
     sizeMax: {
@@ -264,7 +265,7 @@ function shapeSort(a, b) {
           summary: 20
         }
       },
-      control: {type: "number"},
+      control: { type: "number" },
       description: `Sets the size scale maximum to the specified number.`
     },
     sizeMin: {
@@ -277,7 +278,7 @@ function shapeSort(a, b) {
           summary: 5
         }
       },
-      control: {type: "number"},
+      control: { type: "number" },
       description: `Sets the size scale minimum to the specified number.`
     },
     sizeScale: {
@@ -306,7 +307,7 @@ function shapeSort(a, b) {
           summary: false
         }
       },
-      control: {type: "boolean"},
+      control: { type: "boolean" },
       description: `Sets the shape stacking functionality.`
     },
     stackOffset: {
@@ -319,7 +320,7 @@ function shapeSort(a, b) {
           summary: "descending"
         }
       },
-      control: {type: "text"},
+      control: { type: "text" },
       description: `Sets the stack offset.`
     },
     stackOrder: {
@@ -332,7 +333,7 @@ function shapeSort(a, b) {
           summary: "none"
         }
       },
-      control: {type: "text"},
+      control: { type: "text" },
       description: `Sets the stack order.`
     },
     x: {
@@ -345,7 +346,7 @@ function shapeSort(a, b) {
           summary: "x"
         }
       },
-      control: {type: "text"},
+      control: { type: "text" },
       description: `Sets the x accessor to the specified function or number.`
     },
     x2: {
@@ -358,7 +359,7 @@ function shapeSort(a, b) {
           summary: "x2"
         }
       },
-      control: {type: "text"},
+      control: { type: "text" },
       description: `Sets the x2 accessor to the specified function or number.`
     },
     xConfig: {
@@ -381,7 +382,7 @@ function shapeSort(a, b) {
 }`
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `A pass-through to the underlying [Axis](http://d3plus.org/docs/#Axis) config used for the x-axis.`
     },
     xCutoff: {
@@ -394,7 +395,7 @@ function shapeSort(a, b) {
           summary: "undefined"
         }
       },
-      control: {type: "number"},
+      control: { type: "number" },
       description: `When the width of the chart is less than or equal to this pixel value, and the x-axis is not the discrete axis, it will not be shown.`
     },
     x2Config: {
@@ -409,7 +410,7 @@ function shapeSort(a, b) {
 }`
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `A pass-through to the underlying [Axis](http://d3plus.org/docs/#Axis) config used for the x2-axis.`
     },
     xDomain: {
@@ -421,7 +422,7 @@ function shapeSort(a, b) {
           summary: "undefined",
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `Sets the x domain to the specified array.`
     },
     x2Domain: {
@@ -433,7 +434,7 @@ function shapeSort(a, b) {
           summary: "undefined",
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `Sets the x2 domain to the specified array.`
     },
     xSort: {
@@ -445,7 +446,7 @@ function shapeSort(a, b) {
           summary: "undefined",
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `A comparator function that custom sorts discrete x axis.`
     },
     x2Sort: {
@@ -457,7 +458,7 @@ function shapeSort(a, b) {
           summary: "undefined",
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `A comparator function that custom sorts discrete x2 axis.`
     },
     y: {
@@ -470,7 +471,7 @@ function shapeSort(a, b) {
           summary: "y"
         }
       },
-      control: {type: "text"},
+      control: { type: "text" },
       description: `Sets the y accessor to the specified function or number.`
     },
     y2: {
@@ -483,7 +484,7 @@ function shapeSort(a, b) {
           summary: "y2"
         }
       },
-      control: {type: "text"},
+      control: { type: "text" },
       description: `Sets the y2 accessor to the specified function or number.`
     },
     yConfig: {
@@ -506,7 +507,7 @@ function shapeSort(a, b) {
 }`
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `A pass-through to the underlying [Axis](http://d3plus.org/docs/#Axis) config used for the y-axis.`
     },
     yCutoff: {
@@ -519,7 +520,7 @@ function shapeSort(a, b) {
           summary: 150
         }
       },
-      control: {type: "number"},
+      control: { type: "number" },
       description: `When the width of the chart is less than or equal to this pixel value, and the y-axis is not the discrete axis, it will not be shown.`
     },
     y2Config: {
@@ -531,7 +532,7 @@ function shapeSort(a, b) {
           summary: "{}",
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `A pass-through to the underlying [Axis](http://d3plus.org/docs/#Axis) config used for the y2-axis.`
     },
     yDomain: {
@@ -543,7 +544,7 @@ function shapeSort(a, b) {
           summary: "undefined",
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `Sets the y domain to the specified array.`
     },
     y2Domain: {
@@ -555,7 +556,7 @@ function shapeSort(a, b) {
           summary: "undefined",
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `Sets the y2 domain to the specified array.`
     },
     ySort: {
@@ -567,7 +568,7 @@ function shapeSort(a, b) {
           summary: "undefined",
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `A comparator function that custom sorts discrete y axis.`
     },
     y2Sort: {
@@ -579,7 +580,8 @@ function shapeSort(a, b) {
           summary: "undefined",
         }
       },
-      control: {type: "object"},
+      control: { type: "object" },
       description: `A comparator function that custom sorts discrete y2 axis.`
     }
   }
+);

--- a/charts/Plot.stories.js
+++ b/charts/Plot.stories.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import {argTypes, Plot} from './Plot.args';
+import configify from "../helpers/configify";
+
+export default {
+  title: "Charts/Plot",
+  component: Plot,
+  argTypes
+};
+
+const Template = (args) => <Plot config={configify(args, argTypes)} />;
+
+export const GettingStarted = Template.bind({});
+GettingStarted.args = {
+  data: [
+    {id: "alpha", x: 4, y: 7},
+    {id: "beta", x: 5, y: 2},
+    {id: "gamma", x: 6, y: 13}
+  ],
+  groupBy: "id"
+};

--- a/charts/Plot.stories.js
+++ b/charts/Plot.stories.js
@@ -15,7 +15,152 @@ GettingStarted.args = {
   data: [
     {id: "alpha", x: 4, y: 7},
     {id: "beta", x: 5, y: 2},
-    {id: "gamma", x: 6, y: 13}
+    {id: "gamma", x: 6, y: 13},
+    {id: "delta", x: 2, y: 11},
+    {id: "epsilon", x: 5, y: 5},
+    {id: "zeta", x: 3, y: 4},
+    {id: "eta", x: 2.5, y: 6},
+    {id: "theta", x: 5.5, y: 9}
   ],
   groupBy: "id"
+};
+
+export const AddingBackgroundImagesToShapes = Template.bind({});
+AddingBackgroundImagesToShapes.args = {
+  data: "https://oec.world/api/gdp/eci?Year=2019&x=OEC.ECI&y=NY.GDP.MKTP.CD",
+  groupBy: "Country",
+  shapeConfig: {
+    Circle: {
+      backgroundImage: function(d) {return `https://oec.world/images/icons/country/country_${d["Country ID"].slice(2,5)}_circle.png`},
+      label: function () {return ""}
+    }
+  },
+  size: "Trade Value",
+  sizeMax: 50,
+  x: "ECI",
+  xConfig: {
+    title: "Economic Complexity Index (ECI)"
+  },
+  y: "Measure",
+  yConfig: {
+    domain: [100000000, 100000000000000],
+    scale: "log",
+    title: "Gross Domestic Product (GDP)"
+  }
+};
+
+export const AddingTrendLineUsingAnnotations = Template.bind()
+AddingTrendLineUsingAnnotations.args = {
+  data: [
+    "https://api.datamexico.org/tesseract/data.jsonrecords?Year=2020&cube=economy_foreign_trade_ent&drilldowns=State&measures=Trade+Value&parents=false&sparse=false",
+    "https://api.datamexico.org/tesseract/data.jsonrecords?Year=2020&cube=complexity_eci&drilldowns=State&measures=ECI&parents=false&sparse=false"
+  ],
+  groupBy: "State ID",
+  annotations: [
+    {
+      data: [
+        {
+          "id": "Trend",
+          "x": 10000000,
+          "y": -2.5
+        },
+        {
+          "id": "Trend",
+          "x": 1000000000000,
+          "y": 2
+        },
+        {
+          "id": "Baseline",
+          "x": 10000000,
+          "y": 0
+        },
+        {
+          "id": "Baseline",
+          "x": 1000000000000,
+          "y": 0
+        }
+      ],
+      shape: "Line",
+      stroke: function(d) {
+        return d["id"] === "Trend" ? "#6A994E" : "#c3c3c3"
+      },
+      strokeDasharray: "10",
+      strokeWidth: 2
+    }
+  ],
+  label: function(d) {
+    return d["State"]
+  },
+  legend: false,
+  x: "Trade Value",
+  xConfig: {
+    domain: [10000000, 1000000000000],
+    scale: "log"
+  },
+  y: "ECI",
+  yConfig: {
+    domain: [-2.5, 2]
+  }
+}
+
+export const ChangingShapes = Template.bind({});
+ChangingShapes.args = {
+  data: [
+    {"value": 100, "weight": .45,  "name": "alpha"},
+    {"value": 70,  "weight": .60,  "name": "beta"},
+    {"value": 40,  "weight": -.2,  "name": "gamma"},
+    {"value": 15,  "weight": .1,   "name": "delta"},
+    {"value": 5,   "weight": -.43, "name": "epsilon"},
+    {"value": 1,   "weight": 0,    "name": "zeta"}
+  ],
+  groupBy: "name",
+  shape: function(d) {
+    if (d.name === "alpha" || d.name === "delta" || d.name === "epsilon") return "Rect";
+    return "Circle";
+  },
+  size: "value",
+  x: "value",
+  y: "weight"
+};
+
+export const ScatterPlot = Template.bind({});
+ScatterPlot.args = {
+  data: [
+    {id: "alpha", x: 4, y: 7, value: 240},
+    {id: "beta", x: 5, y: 2, value: 120},
+    {id: "gamma", x: 6, y: 13, value: 180}
+  ],
+  groupBy: "id",
+  size: "value",
+  sizeMax: 90,
+  sizeMin: 20
+};
+
+export const SortingShapes = Template.bind({});
+SortingShapes.args = {
+  data: [
+    {id: "alpha", time: 4, value: 240},
+    {id: "beta", time: 5, value: 120},
+    {id: "gamma", time: 6, value: 180},
+    {id: "delta", time: 4, value: 240},
+    {id: "delta", time: 5, value: 120},
+    {id: "delta", time: 6, value: 180}
+  ],
+  groupBy: "id",
+  shape: function(d) {
+    if (d.id === "delta") return "Line";
+    return "Circle";
+  },
+  shapeConfig: {
+    Line: {
+      strokeLinecap: "round",
+      strokeWidth: 5
+    }
+  },
+  shapeSort: function(a, b) {
+    return ["Circle", "Line"].indexOf(b) - ["Circle", "Line"].indexOf(a)
+  },
+  sizeMin: 20,
+  x: "time",
+  y: "value"
 };

--- a/charts/Plot.stories.js
+++ b/charts/Plot.stories.js
@@ -3,7 +3,7 @@ import {argTypes, Plot} from './Plot.args';
 import configify from "../helpers/configify";
 
 export default {
-  title: "Charts/Plot",
+  title: "Charts/ScatterPlot",
   component: Plot,
   argTypes
 };
@@ -123,8 +123,8 @@ ChangingShapes.args = {
   y: "weight"
 };
 
-export const ScatterPlot = Template.bind({});
-ScatterPlot.args = {
+export const BubbleChart = Template.bind({});
+BubbleChart.args = {
   data: [
     {id: "alpha", x: 4, y: 7, value: 240},
     {id: "beta", x: 5, y: 2, value: 120},

--- a/charts/StackedArea.args.js
+++ b/charts/StackedArea.args.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { argTypes as plotArgTypes } from "./Plot.args";
+import { assign } from "d3plus-common";
+
+import { StackedArea as D3plusStackedArea } from "d3plus-react";
+export const StackedArea = ({ config }) => <D3plusStackedArea config={config} />;
+
+export const argTypes = assign(
+
+  /**
+   * Filters out unused argTypes from the Plot args and
+   * overrides any defaults that have been changed in StackedArea
+   */
+  Object.keys(plotArgTypes)
+    .reduce((obj, k) => (obj[k] = plotArgTypes[k], obj), {}),
+
+  /**
+   * StackedArea-specific methods
+   */
+  {
+    shape: {
+      table: {
+        defaultValue: {
+          summary: "Area"
+        }
+      }
+    },
+    stacked: {
+      defaultValue: true,
+      table: {
+        defaultValue: {
+          summary: true
+        }
+      }
+    }
+  }
+);

--- a/charts/StackedArea.stories.js
+++ b/charts/StackedArea.stories.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import {argTypes, StackedArea} from './StackedArea.args';
+import configify from "../helpers/configify";
+
+import { formatAbbreviate } from 'd3plus-format';
+
+export default {
+  title: "Charts/StackedArea",
+  component: StackedArea,
+  argTypes
+};
+
+const Template = (args) => <StackedArea config={configify(args, argTypes)} />;
+
+export const GettingStarted = Template.bind({});
+GettingStarted.args = {
+  data: [
+    {id: "alpha", x: 4, y:  7},
+    {id: "alpha", x: 5, y: 25},
+    {id: "alpha", x: 6, y: 13},
+    {id: "beta",  x: 4, y: 17},
+    {id: "beta",  x: 5, y:  8},
+    {id: "beta",  x: 6, y: 13}
+  ],
+  groupBy: "id"
+};
+
+export const HorizontalStackedAreaChart = Template.bind({});
+HorizontalStackedAreaChart.args = {
+  data: [
+    {id: "alpha", x:  7, y: 4},
+    {id: "alpha", x: 25, y: 5},
+    {id: "alpha", x: 13, y: 6},
+    {id: "beta",  x: 17, y: 4},
+    {id: "beta",  x:  8, y: 5},
+    {id: "beta",  x: 13, y: 6}
+  ],
+  groupBy: "id",
+  discrete: "y"
+};
+
+export const StackedAreaAsSharePercentages = Template.bind({});
+StackedAreaAsSharePercentages.args = {
+  data: [
+    {id: "alpha", x: 4, y:  7},
+    {id: "alpha", x: 5, y: 25},
+    {id: "alpha", x: 6, y: 13},
+    {id: "beta",  x: 4, y: 17},
+    {id: "beta",  x: 5, y:  8},
+    {id: "beta",  x: 6, y: 13},
+    {id: "gamma", x: 4, y: 10},
+    {id: "gamma", x: 5, y: 18},
+    {id: "gamma", x: 6, y:  5}
+  ],
+  groupBy: "id",
+  stackOffset: "expand",
+  yConfig: {
+    tickFormat: function(d) {
+      return `${formatAbbreviate(d * 100)}%`;
+    }
+  }
+};

--- a/charts/Treemap.args.js
+++ b/charts/Treemap.args.js
@@ -1,33 +1,36 @@
 import React from "react";
 import Viz from "../primitives/Viz";
+import { assign } from "d3plus-common";
 
-import {Treemap as D3plusTreemap} from "d3plus-react";
-export const Treemap = ({config}) => <D3plusTreemap config={config} />;
+import { Treemap as D3plusTreemap } from "d3plus-react";
+export const Treemap = ({ config }) => <D3plusTreemap config={config} />;
 
-export const argTypes = {
+export const argTypes = assign(
 
   /**
    * Filters out unused argTypes from the Viz primitive and
    * overrides any defaults that have been changed in Treemap
    */
-  ...Object.keys(Viz.argTypes)
+  Object.keys(Viz.argTypes)
     .filter(k => !k.match(/^(discrete|shape|zoom.*)$/))
     .reduce((obj, k) => (obj[k] = Viz.argTypes[k], obj), {}),
 
   /**
    * Treemap-specific methods
    */
-  sum: {
-    type: {
-      summary: "string | function",
-      required: true
-    },
-    table: {
-      defaultValue: {
-        summary: "\"value\"",
-        detail: `d => d.value`
-      }
-    },
-    description: `The accessor key for each data point used to calculate the size of each rectangle.`
+  {
+    sum: {
+      type: {
+        summary: "string | function",
+        required: true
+      },
+      table: {
+        defaultValue: {
+          summary: "\"value\"",
+          detail: `d => d.value`
+        }
+      },
+      description: `The accessor key for each data point used to calculate the size of each rectangle.`
+    }
   }
-}
+);

--- a/helpers/configify.js
+++ b/helpers/configify.js
@@ -2,13 +2,25 @@
  * removes undefined config keys, which may cause issues with d3plus
  * and also pollute the "Code" view in Docs
  */
+import Viz from "../primitives/Viz";
+
 export default function(args, argTypes) {
+  const _argTypes = argTypes;
+  Object.keys(Viz.argTypes).reduce((acc, key) => {
+    if (
+      argTypes[key] !== undefined && JSON.stringify(Viz.argTypes[key]) !== JSON.stringify(argTypes[key])
+    ) _argTypes[key] = Object.assign(Viz.argTypes[key], argTypes[key], {});
+  
+    return _argTypes;
+  }, {});
+
   return Object.keys(args).reduce((acc, key) => {
-   const _acc = acc;
-   if (
-     args[key] !== undefined &&
-     (argTypes[key].defaultValue === undefined || JSON.stringify(argTypes[key].defaultValue) !== JSON.stringify(args[key]))
-   ) _acc[key] = args[key];
-   return _acc;
- }, {});
+    const _acc = acc;
+    if (
+      args[key] !== undefined &&
+      (_argTypes[key].defaultValue === undefined || JSON.stringify(_argTypes[key].defaultValue) !== JSON.stringify(args[key]))
+    ) _acc[key] = args[key];
+
+    return _acc;
+  }, {});
 }

--- a/helpers/configify.js
+++ b/helpers/configify.js
@@ -2,25 +2,14 @@
  * removes undefined config keys, which may cause issues with d3plus
  * and also pollute the "Code" view in Docs
  */
-import Viz from "../primitives/Viz";
 
 export default function(args, argTypes) {
-  const _argTypes = argTypes;
-  Object.keys(Viz.argTypes).reduce((acc, key) => {
-    if (
-      argTypes[key] !== undefined && JSON.stringify(Viz.argTypes[key]) !== JSON.stringify(argTypes[key])
-    ) _argTypes[key] = Object.assign(Viz.argTypes[key], argTypes[key], {});
-  
-    return _argTypes;
-  }, {});
-
   return Object.keys(args).reduce((acc, key) => {
-    const _acc = acc;
-    if (
-      args[key] !== undefined &&
-      (_argTypes[key].defaultValue === undefined || JSON.stringify(_argTypes[key].defaultValue) !== JSON.stringify(args[key]))
-    ) _acc[key] = args[key];
-
-    return _acc;
-  }, {});
+   const _acc = acc;
+   if (
+     args[key] !== undefined &&
+     (argTypes[key].defaultValue === undefined || JSON.stringify(argTypes[key].defaultValue) !== JSON.stringify(args[key]))
+   ) _acc[key] = args[key];
+   return _acc;
+ }, {});
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6859,21 +6859,6 @@
         "topojson-client": "^3.1.0"
       }
     },
-    "d3plus-hierarchy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d3plus-hierarchy/-/d3plus-hierarchy-1.0.0.tgz",
-      "integrity": "sha512-GV4BzEhbC0PmFotjok0MLncqZ8PfqmGfYys4INoMkL8TccXsqDa1EDZ9XmsqrOvm4U42WlVNBp9Sr/1Yp8UPGw==",
-      "requires": {
-        "d3-array": "^2.11.0",
-        "d3-collection": "^1.0.7",
-        "d3-hierarchy": "^2.0.0",
-        "d3-scale": "^3.2.3",
-        "d3-shape": "^2.0.0",
-        "d3plus-common": "^1.0.1",
-        "d3plus-shape": "^1.0.1",
-        "d3plus-viz": "^1.0.1"
-      }
-    },
     "d3plus-legend": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/d3plus-legend/-/d3plus-legend-1.0.3.tgz",
@@ -6903,24 +6888,10 @@
         "d3plus-viz": "^1.0.3"
       }
     },
-    "d3plus-network": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d3plus-network/-/d3plus-network-1.0.0.tgz",
-      "integrity": "sha512-eD7nLRlvyfN4U2F0kASOEsl4PoR/gKRWuGSAEm+31oEoHBESKmgkRIG/lzWLLzW/t+Iool7RzD8Scf2i5N5XVQ==",
-      "requires": {
-        "d3-array": "^2.11.0",
-        "d3-force": "^2.1.1",
-        "d3-sankey": "^0.12.3",
-        "d3-scale": "^3.2.3",
-        "d3plus-common": "^1.0.2",
-        "d3plus-shape": "^1.0.1",
-        "d3plus-viz": "^1.0.3"
-      }
-    },
     "d3plus-plot": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/d3plus-plot/-/d3plus-plot-1.0.8.tgz",
-      "integrity": "sha512-9z3QyRS9xRov32Nx5W5sN2woxN750UNvbkMgrBUYXFbyLhIsQafSIUxiNjIp8XRIMt6jS278RQxSQo3UHtVAag==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/d3plus-plot/-/d3plus-plot-1.0.11.tgz",
+      "integrity": "sha512-RqMLxJHCB4LO8x9OmBbwR6A4dzr4zp8lq93mwaZkRt8TIYZoKhMb2Ea4Lp/zPO+yxZl9d0TTb6Rb1rrhaGwU5g==",
       "requires": {
         "d3-array": "^2.12.1",
         "d3-collection": "^1.0.7",
@@ -6931,7 +6902,7 @@
         "d3plus-color": "^1.0.0",
         "d3plus-common": "^1.0.4",
         "d3plus-shape": "^1.0.3",
-        "d3plus-viz": "^1.0.7"
+        "d3plus-viz": "^1.0.8"
       }
     },
     "d3plus-priestley": {
@@ -6949,18 +6920,73 @@
       }
     },
     "d3plus-react": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d3plus-react/-/d3plus-react-1.0.0.tgz",
-      "integrity": "sha512-00FY7jhYy8Kg3xQyp2Lr0N5GDIBajm802yCE0RyIE5iTGRlI2huLEBfuZYkFItUWIeS27DWs9ol/df+M91pRvg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d3plus-react/-/d3plus-react-1.0.1.tgz",
+      "integrity": "sha512-qLCfkn852rIuatuFRQ6sh4LeFc7Nhw4Tg2UU5iomT5g8MtCfZYHpdRbqP6bnonInBK6ogo7TkuifkSftTuRLyQ==",
       "requires": {
-        "d3plus-common": "^1.0.2",
+        "d3plus-common": "^1.0.4",
         "d3plus-geomap": "^1.0.0",
-        "d3plus-hierarchy": "^1.0.0",
-        "d3plus-matrix": "^1.0.0",
-        "d3plus-network": "^1.0.0",
-        "d3plus-plot": "^1.0.0",
+        "d3plus-hierarchy": "^1.0.1",
+        "d3plus-matrix": "^1.0.3",
+        "d3plus-network": "^1.0.2",
+        "d3plus-plot": "^1.0.11",
         "d3plus-priestley": "^1.0.0",
-        "d3plus-viz": "^1.0.3"
+        "d3plus-viz": "^1.0.9"
+      },
+      "dependencies": {
+        "d3plus-hierarchy": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/d3plus-hierarchy/-/d3plus-hierarchy-1.0.1.tgz",
+          "integrity": "sha512-x7UzqHBReubV2QWJQ3CUNXDhNpWSve77iu41j9DlFFkEVTAF1WlH/XgCKhNDLrrmsdSfuaxnWbaoFCafSNSz7w==",
+          "requires": {
+            "d3-array": "^2.11.0",
+            "d3-collection": "^1.0.7",
+            "d3-hierarchy": "^2.0.0",
+            "d3-scale": "^3.2.3",
+            "d3-shape": "^2.0.0",
+            "d3plus-common": "^1.0.1",
+            "d3plus-shape": "^1.0.1",
+            "d3plus-viz": "^1.0.1"
+          }
+        },
+        "d3plus-network": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/d3plus-network/-/d3plus-network-1.0.2.tgz",
+          "integrity": "sha512-4WgS039U982p8PnnQaMIJbQy3eb8PPLMnJDkd8SRmAIV1N5QOdi992nvnFJUpnKJctro+gKy1O8DlA+h6N0GVg==",
+          "requires": {
+            "d3-array": "^2.11.0",
+            "d3-force": "^2.1.1",
+            "d3-sankey": "^0.12.3",
+            "d3-scale": "^3.2.3",
+            "d3plus-common": "^1.0.4",
+            "d3plus-shape": "^1.0.3",
+            "d3plus-viz": "^1.0.9"
+          }
+        },
+        "d3plus-viz": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/d3plus-viz/-/d3plus-viz-1.0.9.tgz",
+          "integrity": "sha512-qsOTz3GIvRF9Jtb8dTN4e6Lf+58SDajghB+Wfy81ngB5Z0sj+dm+55uVDlXhd/yUlQCzSm2IwFeArPUqhN2Zvw==",
+          "requires": {
+            "d3-array": "^2.11.0",
+            "d3-brush": "^2.1.0",
+            "d3-color": "^2.0.0",
+            "d3-queue": "^3.0.7",
+            "d3-request": "^1.0.6",
+            "d3-selection": "^2.0.0",
+            "d3-zoom": "^2.0.0",
+            "d3plus-axis": "^1.0.0",
+            "d3plus-color": "^1.0.0",
+            "d3plus-common": "^1.0.2",
+            "d3plus-export": "^1.0.0",
+            "d3plus-format": "^1.0.0",
+            "d3plus-legend": "^1.0.2",
+            "d3plus-text": "^1.0.1",
+            "d3plus-timeline": "^1.0.0",
+            "d3plus-tooltip": "^1.0.0",
+            "lrucache": "^1.0.3"
+          }
+        }
       }
     },
     "d3plus-shape": {


### PR DESCRIPTION
This PR adds new arguments and examples to Plot and Plot extensions Viz types (LinePlot, BarChart, Area, and more).
It also modifies `*.args.js` files to includes d3plus `assign` function that allows us to fill incomplete objects with Viz or Plot args definitions.
For now, this PR will be a draft to work into args descriptions and control types (@davelandry can you take a look on it?).