### PR TITLE
enables function printouts

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,5 +5,8 @@ export const parameters = {
   controls: {
     expanded: false,
     sort: "requiredFirst"
+  },
+  jsx: {
+    showFunctions: true
   }
 }

--- a/helpers/funcify.js
+++ b/helpers/funcify.js
@@ -1,0 +1,13 @@
+/**
+ * allows overwriting the default toString method of a function
+ * in order for pretty doc printouts
+ */
+ export default function(fn, str) {
+
+  /** A toString to render the function in storybook */
+  // eslint-disable-next-line no-param-reassign
+  fn.toString = () => str;
+
+  return fn;
+
+}


### PR DESCRIPTION
@ffigueroal I figured out how to show functions! 

`showFunctions: true` 🤦🏻 

Took me a little while of digging through the storybook source code and tracing around options, but this works out of the box!

Now, the automatic display of fat arrow functions like `d => d.id` get stringified to something like `function(d){ return d.id;}`, which doesn't look the prettiest, so I'm also including a `funcify` function that allows for overriding the string display of functions, which would be used like this:

```jsx
groupBy: funcify(d => d.id, "d => d.id")
```