### PR TITLE
[LinePlot] Quarterly Data Example

### DIFF
--- a/advanced/LinePlot.stories.js
+++ b/advanced/LinePlot.stories.js
@@ -644,3 +644,13 @@ DottedLinePredictions.args = {
   x: "Year",
   y: "Trade Value"
 };
+
+export const QuarterlyData = Template.bind({});
+QuarterlyData.args = {
+  data: "https://api.datamexico.org/tesseract/data.jsonrecords?cube=fdi_9_quarter_investment&drilldowns=Quarter,Investment+Type&measures=Investment",
+  groupBy: "Investment Type",
+  time: "Quarter",
+  timeline: false,
+  x: "Quarter",
+  y: "Investment"
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8708,19 +8708,19 @@
       }
     },
     "d3plus-axis": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3plus-axis/-/d3plus-axis-1.0.6.tgz",
-      "integrity": "sha512-rrzEBAQigTHsxnq2u+IGxuGy2LYcnkcMcyxEHV90AXhUut80KTUP3n07Cyzs2wWp1IHt0hY6cCW1TPbmsu/S4g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/d3plus-axis/-/d3plus-axis-1.1.1.tgz",
+      "integrity": "sha512-h1Gw4wWkeYwc4mqpjv7FdWrYSwFMgCIBsvz978m/1neP310TQVen4PsqS0OFxlH3czH74yfbQguyYFFqXGgZHQ==",
       "requires": {
         "d3-array": "^2.12.1",
         "d3-scale": "^3.3.0",
         "d3-selection": "^2.0.0",
         "d3-transition": "^2.0.0",
         "d3plus-color": "^1.0.0",
-        "d3plus-common": "^1.0.4",
-        "d3plus-format": "^1.0.1",
-        "d3plus-shape": "^1.0.3",
-        "d3plus-text": "^1.0.1"
+        "d3plus-common": "^1.0.6",
+        "d3plus-format": "^1.1.1",
+        "d3plus-shape": "^1.0.4",
+        "d3plus-text": "^1.0.2"
       }
     },
     "d3plus-color": {
@@ -8733,9 +8733,9 @@
       }
     },
     "d3plus-common": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-1.0.5.tgz",
-      "integrity": "sha512-RrWIUMIUrVO5o0u0Mt626pYCzxRbZ1oMwq6wIHn9Tuzu5zRFtGARkCkq1OwGnaHxcoQmtdlXbNky8zDh2zkUbw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3plus-common/-/d3plus-common-1.0.6.tgz",
+      "integrity": "sha512-gkNG5HJ2yhbmPEQhLXIm4jzF8XKx0lilJPRqa0WDd2pH4J7sS+KM1LTf7v4CjyrNUT0i4jxuZh/b5Ez8kzBEUA==",
       "requires": {
         "d3-array": "^2.11.0",
         "d3-collection": "^1.0.7",
@@ -8758,9 +8758,9 @@
       }
     },
     "d3plus-format": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/d3plus-format/-/d3plus-format-1.0.2.tgz",
-      "integrity": "sha512-QnGlCOczU0WvL06wrRwPdYik0BqlbZOwyGQqO4lGunO+yCNgR/79stIVrHORgbihWSyWVt4QzbTHcsF/onmtKg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/d3plus-format/-/d3plus-format-1.1.1.tgz",
+      "integrity": "sha512-QJqHPQAseSbl+kiFBLXIgdZZFHOBrJck77pMdGJRpVuNBnZTuBFneOxVmhyyXU6qvJ/FtflSTObfqwJwPN0Emw==",
       "requires": {
         "d3-format": "^2.0.0",
         "d3-time": "^2.1.1",
@@ -8845,21 +8845,21 @@
       }
     },
     "d3plus-plot": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/d3plus-plot/-/d3plus-plot-1.0.15.tgz",
-      "integrity": "sha512-hHfl4vSAkOxc2I/jM4HOrquQELmFXd1S5smxUmE0rYItQK3v8nliyi+R+k9eUNu+Djr82PTsyPgHMGAkw9fOhQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3plus-plot/-/d3plus-plot-1.1.0.tgz",
+      "integrity": "sha512-ASpiryBVf/AVouXRVmcgibz/WYEm5vAiK7gNM7zqLXkCoHVh/OIIz3aIgXMRmp/AtqDdsnYMDosMDT2AOqPpJQ==",
       "requires": {
         "d3-array": "^2.12.1",
         "d3-collection": "^1.0.7",
         "d3-scale": "^3.3.0",
         "d3-selection": "^2.0.0",
         "d3-shape": "^2.1.0",
-        "d3plus-axis": "^1.0.6",
+        "d3plus-axis": "^1.1.1",
         "d3plus-color": "^1.0.0",
-        "d3plus-common": "^1.0.5",
-        "d3plus-format": "^1.0.1",
-        "d3plus-shape": "^1.0.3",
-        "d3plus-viz": "^1.0.8"
+        "d3plus-common": "^1.0.6",
+        "d3plus-format": "^1.1.1",
+        "d3plus-shape": "^1.0.4",
+        "d3plus-viz": "^1.0.11"
       }
     },
     "d3plus-priestley": {
@@ -8877,24 +8877,24 @@
       }
     },
     "d3plus-react": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/d3plus-react/-/d3plus-react-1.0.2.tgz",
-      "integrity": "sha512-iiDjKCvBZCdESzI/GjAdj5aUwsybhxpHwvnUcK97UCguJfhxh+tiZCF1zGwXShMpHE12/09Ro0NaiKYba2ChJQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/d3plus-react/-/d3plus-react-1.1.1.tgz",
+      "integrity": "sha512-PvHdy3LCEn/ekJCiycATHvLfS7E5DqghVbqWO5Fmrz+/GIq4R1+7+ITSDuzjM845jM+OHMZuk3rOyHJ54IUSqQ==",
       "requires": {
-        "d3plus-common": "^1.0.4",
+        "d3plus-common": "^1.0.6",
         "d3plus-geomap": "^1.0.0",
         "d3plus-hierarchy": "^1.0.1",
         "d3plus-matrix": "^1.0.3",
         "d3plus-network": "^1.0.2",
-        "d3plus-plot": "^1.0.11",
+        "d3plus-plot": "^1.1.0",
         "d3plus-priestley": "^1.0.0",
-        "d3plus-viz": "^1.0.9"
+        "d3plus-viz": "^1.1.0"
       }
     },
     "d3plus-shape": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/d3plus-shape/-/d3plus-shape-1.0.3.tgz",
-      "integrity": "sha512-ArhgU+FtZPJ9pWBS553UKvP57b2jPjQkp85vnnMe6LJyamEf/3rBc1YxYRHw7oLEMRT9l58WxMuceA1je3uKsw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/d3plus-shape/-/d3plus-shape-1.0.4.tgz",
+      "integrity": "sha512-6GnRTDkLCKunAcZIq9kbCnYZavfrwnqdJZPCez/Y8TDACWVIur7HMWwOlzLW7rodJ+8KWL2KM2ov6+F22zAIow==",
       "requires": {
         "d3-array": "^2.11.0",
         "d3-collection": "^1.0.7",
@@ -8905,8 +8905,8 @@
         "d3-shape": "^2.0.0",
         "d3-transition": "^2.0.0",
         "d3plus-color": "^1.0.0",
-        "d3plus-common": "^1.0.0",
-        "d3plus-text": "^1.0.1"
+        "d3plus-common": "^1.0.6",
+        "d3plus-text": "^1.0.2"
       }
     },
     "d3plus-text": {
@@ -8944,9 +8944,9 @@
       }
     },
     "d3plus-viz": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3plus-viz/-/d3plus-viz-1.0.9.tgz",
-      "integrity": "sha512-qsOTz3GIvRF9Jtb8dTN4e6Lf+58SDajghB+Wfy81ngB5Z0sj+dm+55uVDlXhd/yUlQCzSm2IwFeArPUqhN2Zvw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3plus-viz/-/d3plus-viz-1.1.0.tgz",
+      "integrity": "sha512-GKlqZSO7BTAOz1qxUn8QwZUqMua+Eo8NnUw/6E1d+d9E2sMw9TsL84kIknjADbdqc4JKwKgRLwxc3uyzAAwkeg==",
       "requires": {
         "d3-array": "^2.11.0",
         "d3-brush": "^2.1.0",
@@ -8955,15 +8955,15 @@
         "d3-request": "^1.0.6",
         "d3-selection": "^2.0.0",
         "d3-zoom": "^2.0.0",
-        "d3plus-axis": "^1.0.0",
+        "d3plus-axis": "^1.1.1",
         "d3plus-color": "^1.0.0",
-        "d3plus-common": "^1.0.2",
-        "d3plus-export": "^1.0.0",
-        "d3plus-format": "^1.0.0",
-        "d3plus-legend": "^1.0.2",
-        "d3plus-text": "^1.0.1",
+        "d3plus-common": "^1.0.6",
+        "d3plus-export": "^1.0.1",
+        "d3plus-format": "^1.1.1",
+        "d3plus-legend": "^1.0.3",
+        "d3plus-text": "^1.0.2",
         "d3plus-timeline": "^1.0.0",
-        "d3plus-tooltip": "^1.0.0",
+        "d3plus-tooltip": "^1.0.1",
         "lrucache": "^1.0.3"
       }
     },
@@ -11522,9 +11522,9 @@
       }
     },
     "internmap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.0.tgz",
-      "integrity": "sha512-SdoDWwNOTE2n4JWUsLn4KXZGuZPjPF9yyOGc8bnfWnBQh7BD/l80rzSznKc/r4Y0aQ7z3RTk9X+tV4tHBpu+dA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "interpret": {
       "version": "2.2.0",
@@ -16504,13 +16504,6 @@
       "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
       "requires": {
         "commander": "2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        }
       }
     },
     "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chromatic": "^5.8.0"
   },
   "dependencies": {
-    "d3plus-react": "^1.0.0",
+    "d3plus-react": "^1.1.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "typescript": "^3.9.9"


### PR DESCRIPTION
I've added quarterly time resolution support baked into d3plus-axis and d3plus-format, and this new example shows how it looks using a DataMexico API (if you can guess, I'd like to share this example with Ryan once published 😏)

https://60148c90e6c64a002198924e-cnfmshqudi.chromatic.com/?path=/story/advanced-lineplot--quarterly-data

<img width="1385" alt="Screen Shot 2022-01-12 at 3 20 38 PM" src="https://user-images.githubusercontent.com/1847581/149215659-a30991c4-d065-485a-abdd-4c0465d9102a.png">

